### PR TITLE
Handle request timeouts and unauthorized errors

### DIFF
--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -3,6 +3,9 @@ package com.eppo.sdk;
 import com.eppo.sdk.constants.Constants;
 import com.eppo.sdk.dto.*;
 import com.eppo.sdk.helpers.*;
+
+import lombok.extern.slf4j.Slf4j;
+
 import com.eppo.sdk.exception.*;
 import org.ehcache.Cache;
 
@@ -10,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Timer;
 
+@Slf4j
 public class EppoClient {
     /**
      * Static Instance
@@ -47,6 +51,10 @@ public class EppoClient {
 
         // Fetch Experiment Configuration
         ExperimentConfiguration configuration = this.configurationStore.getExperimentConfiguration(experimentKey);
+        if (configuration == null) {
+            log.warn("No configuration found for experiment key: " + experimentKey);
+            return Optional.empty();
+        }
 
         // Check if subject has override variations
         String subjectVariationOverride = this.getSubjectVariationOverride(subjectKey, configuration);

--- a/src/main/java/com/eppo/sdk/exception/InvalidApiKeyException.java
+++ b/src/main/java/com/eppo/sdk/exception/InvalidApiKeyException.java
@@ -1,0 +1,7 @@
+package com.eppo.sdk.exception;
+
+public class InvalidApiKeyException extends RuntimeException {
+  public InvalidApiKeyException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -92,9 +92,6 @@ public class ConfigurationStore {
      * @throws NetworkRequestNotAllowed
      */
     public void fetchAndSetExperimentConfiguration() throws NetworkException, NetworkRequestNotAllowed {
-        if (!this.isFetchingExperimentConfigurationAllowed()) {
-            throw new NetworkRequestNotAllowed("Fetching Experiment Configuration is not allowed");
-        }
         Optional<ExperimentConfigurationResponse> response = this.experimentConfigurationRequestor
                 .fetchExperimentConfiguration();
 
@@ -103,14 +100,5 @@ public class ConfigurationStore {
                 this.setExperimentConfiguration(entry.getKey(), entry.getValue());
             }
         }
-    }
-
-    /**
-     * This function is used to check if it is allowed to fetch experiment configuration from network
-     *
-     * @return
-     */
-    public boolean isFetchingExperimentConfigurationAllowed() {
-        return this.experimentConfigurationRequestor.isRequestAllowed();
     }
 }

--- a/src/main/java/com/eppo/sdk/helpers/FetchConfigurationsTask.java
+++ b/src/main/java/com/eppo/sdk/helpers/FetchConfigurationsTask.java
@@ -15,11 +15,9 @@ public class FetchConfigurationsTask extends TimerTask {
 
   @Override
   public void run() {
-    if (configurationStore.isFetchingExperimentConfigurationAllowed()) {
-      configurationStore.fetchAndSetExperimentConfiguration();
-      long delay = this.intervalInMillis - ((long) Math.random() * this.jitterInMillis);
-      FetchConfigurationsTask nextTask = new FetchConfigurationsTask(configurationStore, timer, intervalInMillis, jitterInMillis);
-      timer.schedule(nextTask, delay);
-    }
+    configurationStore.fetchAndSetExperimentConfiguration();
+    long delay = this.intervalInMillis - ((long) Math.random() * this.jitterInMillis);
+    FetchConfigurationsTask nextTask = new FetchConfigurationsTask(configurationStore, timer, intervalInMillis, jitterInMillis);
+    timer.schedule(nextTask, delay);
   }
 }


### PR DESCRIPTION
## Description
Fixes a couple bugs with the configuration requestor:
- It treated request timeouts as fatal errors - these should not stop the polling process
- It did not give a meaningful error for the unauthorized case, just said "Request not allowed"
- There was no logging of non-fatal errors - I added [SLF4j logger](https://www.slf4j.org/). SLF4j is a facade that allows consumers of the SDK to choose their logging implementation ([reference](https://stackoverflow.com/a/69511735)).

## Testing
Verified the following cases:
- Invalid API key throws error during initialization
- Simulated a request timeout by adding a delay to the RAC endpoint
- Tried other fatal exceptions such as an invalid base URL