### PR TITLE
Migrate Java SDK to use V2 Randomization Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 target/
 out/
 src/test/resources/assignment-v2
-src/test/resources/rac-experiments.json
+src/test/resources/rac-experiments-v2.json

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ testDataDir := src/test/resources/
 test-data: 
 	rm -rf $(testDataDir)
 	mkdir -p $(testDataDir)
-	gsutil cp gs://sdk-test-data/rac-experiments.json $(testDataDir)
+	gsutil cp gs://sdk-test-data/rac-experiments-v2.json $(testDataDir)
 	gsutil cp -r gs://sdk-test-data/assignment-v2 $(testDataDir)
 
 .PHONY: test

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -86,7 +86,7 @@ public class EppoClient {
         // Find matched rule
         Optional<Rule> rule = RuleValidator.findMatchingRule(subjectAttributes, configuration.getRules());
         if (rule.isEmpty()) {
-            log.info("[Eppo SDK] No assigned variation. The subject attributes {} did not match any targeting rules", subjectAttributes);
+            log.info("[Eppo SDK] No assigned variation. The subject attributes did not match any targeting rules");
             return Optional.empty();
         }
 

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -1,12 +1,28 @@
 package com.eppo.sdk;
 
 import com.eppo.sdk.constants.Constants;
-import com.eppo.sdk.dto.*;
-import com.eppo.sdk.helpers.*;
+import com.eppo.sdk.dto.Allocation;
+import com.eppo.sdk.dto.AssignmentLogData;
+import com.eppo.sdk.dto.EppoClientConfig;
+import com.eppo.sdk.dto.EppoValue;
+import com.eppo.sdk.dto.ExperimentConfiguration;
+import com.eppo.sdk.dto.Rule;
+import com.eppo.sdk.dto.SubjectAttributes;
+import com.eppo.sdk.dto.Variation;
+import com.eppo.sdk.exception.EppoClientIsNotInitializedException;
+import com.eppo.sdk.exception.InvalidInputException;
+import com.eppo.sdk.helpers.AppDetails;
+import com.eppo.sdk.helpers.CacheHelper;
+import com.eppo.sdk.helpers.ConfigurationStore;
+import com.eppo.sdk.helpers.EppoHttpClient;
+import com.eppo.sdk.helpers.ExperimentConfigurationRequestor;
+import com.eppo.sdk.helpers.FetchConfigurationsTask;
+import com.eppo.sdk.helpers.InputValidator;
+import com.eppo.sdk.helpers.RuleValidator;
+import com.eppo.sdk.helpers.Shard;
 
 import lombok.extern.slf4j.Slf4j;
 
-import com.eppo.sdk.exception.*;
 import org.ehcache.Cache;
 
 import java.util.List;
@@ -35,55 +51,67 @@ public class EppoClient {
      * This function is used to get assignment Value
      *
      * @param subjectKey
-     * @param experimentKey
+     * @param flagKey
      * @param subjectAttributes
      * @return
      */
     public Optional<String> getAssignment(
             String subjectKey,
-            String experimentKey,
+            String flagKey,
             SubjectAttributes subjectAttributes
     ) {
         // Validate Input Values
         InputValidator.validateNotBlank(subjectKey, "Invalid argument: subjectKey cannot be blank");
-        InputValidator.validateNotBlank(experimentKey, "Invalid argument: experimentKey cannot be blank");
+        InputValidator.validateNotBlank(flagKey, "Invalid argument: flagKey cannot be blank");
 
         // Fetch Experiment Configuration
-        ExperimentConfiguration configuration = this.configurationStore.getExperimentConfiguration(experimentKey);
+        ExperimentConfiguration configuration = this.configurationStore.getExperimentConfiguration(flagKey);
         if (configuration == null) {
-            log.warn("No configuration found for experiment key: " + experimentKey);
+            log.warn("[Eppo SDK] No configuration found for key: " + flagKey);
             return Optional.empty();
         }
 
         // Check if subject has override variations
-        String subjectVariationOverride = this.getSubjectVariationOverride(subjectKey, configuration);
-        if (subjectVariationOverride != null) {
-            return Optional.of(subjectVariationOverride);
+        EppoValue subjectVariationOverride = this.getSubjectVariationOverride(subjectKey, configuration);
+        if (!subjectVariationOverride.isNull()) {
+            return Optional.of(subjectVariationOverride.stringValue());
         }
 
-        // If disabled or not in Experiment Sampler or Rules not satisfied return empty string
-        if (!configuration.enabled ||
-                !this.isInExperimentSample(subjectKey, experimentKey, configuration) ||
-                !this.subjectAttributesSatisfyRules(subjectAttributes, configuration.rules)
-        ) {
+        // Check if disabled
+        if (!configuration.isEnabled()) {
+            log.info("[Eppo SDK] No assigned variation because the experiment or feature flag {} is disabled", flagKey);
+            return Optional.empty();
+        }
+
+        // Find matched rule
+        Optional<Rule> rule = RuleValidator.findMatchingRule(subjectAttributes, configuration.getRules());
+        if (rule.isEmpty()) {
+            log.info("[Eppo SDK] No assigned variation. The subject attributes {} did not match any targeting rules", subjectAttributes);
+            return Optional.empty();
+        }
+
+        // Check if in experiment sample
+        Allocation allocation = configuration.getAllocation(rule.get().getAllocationKey());
+        if (!this.isInExperimentSample(subjectKey, flagKey, configuration.getSubjectShards(), allocation.getPercentExposure())) {
+            log.info("[Eppo SDK] No assigned variation. The subject is not part of the sample population");
             return Optional.empty();
         }
 
         // Get assigned variation
-        Variation assignedVariation = this.getAssignedVariation(subjectKey, experimentKey, configuration);
+        Variation assignedVariation = this.getAssignedVariation(subjectKey, flagKey, configuration.getSubjectShards(), allocation.getVariations());
 
         try {
             this.eppoClientConfig.getAssignmentLogger()
                 .logAssignment(new AssignmentLogData(
-                        experimentKey,
-                        assignedVariation.name,
+                        flagKey,
+                        assignedVariation.getValue().stringValue(),
                         subjectKey,
                         subjectAttributes
                 ));
         } catch (Exception e){
             // Ignore Exception
         }
-        return Optional.of(assignedVariation.name);
+        return Optional.of(assignedVariation.getValue().stringValue());
     }
 
     /**
@@ -108,11 +136,9 @@ public class EppoClient {
     private boolean isInExperimentSample(
             String subjectKey,
             String experimentKey,
-            ExperimentConfiguration experimentConfiguration
+            int subjectShards,
+            float percentageExposure
     ) {
-        int subjectShards = experimentConfiguration.subjectShards;
-        float percentageExposure = experimentConfiguration.percentExposure;
-
         int shard = Shard.getShard("exposure-" + subjectKey + "-" + experimentKey, subjectShards);
         return shard <= percentageExposure * subjectShards;
     }
@@ -128,13 +154,13 @@ public class EppoClient {
     private Variation getAssignedVariation(
             String subjectKey,
             String experimentKey,
-            ExperimentConfiguration experimentConfiguration
+            int subjectShards,
+            List<Variation> variations
     ) {
-        int subjectShards = experimentConfiguration.subjectShards;
         int shard = Shard.getShard("assignment-" + subjectKey + "-" + experimentKey, subjectShards);
 
-        Optional<Variation> variation = experimentConfiguration.variations.stream()
-                .filter(config -> Shard.isShardInRange(shard, config.shardRange))
+        Optional<Variation> variation = variations.stream()
+                .filter(config -> Shard.isShardInRange(shard, config.getShardRange()))
                 .findFirst();
 
         return variation.get();
@@ -147,30 +173,12 @@ public class EppoClient {
      * @param experimentConfiguration
      * @return
      */
-    private String getSubjectVariationOverride(
+    private EppoValue getSubjectVariationOverride(
             String subjectKey,
             ExperimentConfiguration experimentConfiguration
     ) {
         String hexedSubjectKey = Shard.getHex(subjectKey);
-        return experimentConfiguration.overrides.getOrDefault(hexedSubjectKey, null);
-    }
-
-    /**
-     * This function is used to test if subject attributes are satisfying rules or not
-     *
-     * @param subjectAttributes
-     * @param rules
-     * @return
-     * @throws Exception
-     */
-    private boolean subjectAttributesSatisfyRules(
-            SubjectAttributes subjectAttributes,
-            List<Rule> rules
-    ) {
-        if (rules.size() == 0) {
-            return true;
-        }
-        return RuleValidator.matchesAnyRule(subjectAttributes, rules);
+        return experimentConfiguration.getOverrides().getOrDefault(hexedSubjectKey, new EppoValue());
     }
 
     /***

--- a/src/main/java/com/eppo/sdk/constants/Constants.java
+++ b/src/main/java/com/eppo/sdk/constants/Constants.java
@@ -31,7 +31,7 @@ public class Constants {
     /**
      * RAC settings
      */
-    public static final String RAC_ENDPOINT = "/randomized_assignment/config";
+    public static final String RAC_ENDPOINT = "/randomized_assignment/v2/config";
 
 
     /**

--- a/src/main/java/com/eppo/sdk/dto/Allocation.java
+++ b/src/main/java/com/eppo/sdk/dto/Allocation.java
@@ -1,0 +1,11 @@
+package com.eppo.sdk.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class Allocation {
+  private float percentExposure;
+  private List<Variation> variations;
+}

--- a/src/main/java/com/eppo/sdk/dto/ExperimentConfiguration.java
+++ b/src/main/java/com/eppo/sdk/dto/ExperimentConfiguration.java
@@ -3,22 +3,21 @@ package com.eppo.sdk.dto;
 import java.util.List;
 import java.util.Map;
 
+import lombok.Data;
+
 /**
  * Experiment Configuration Class
  */
+@Data
 public class ExperimentConfiguration {
-    public String name;
-    public boolean enabled;
-    public int subjectShards;
-    public float percentExposure;
-    public List<Variation> variations;
-    public Map<String, String> overrides;
-    public List<Rule> rules;
+    private String name;
+    private boolean enabled;
+    private int subjectShards;
+    private Map<String, EppoValue> overrides;
+    private Map<String, Allocation> allocations;
+    private List<Rule> rules;
 
-    @Override
-    public String toString() {
-        return "[Name: " + name + " | Enabled: " + enabled + " | SubjectShards: " +
-                subjectShards + " | PercentExposure: " + percentExposure + " | Variations: " +
-                variations.toString() + " | Overrides: " + overrides.toString() + " | Rules: " + rules.toString() +  "]";
+    public Allocation getAllocation(String allocationKey) {
+        return getAllocations().get(allocationKey);
     }
 }

--- a/src/main/java/com/eppo/sdk/dto/ExperimentConfigurationResponse.java
+++ b/src/main/java/com/eppo/sdk/dto/ExperimentConfigurationResponse.java
@@ -2,14 +2,12 @@ package com.eppo.sdk.dto;
 
 import java.util.Map;
 
+import lombok.Data;
+
 /**
  * Experiment Configuration Response Class
  */
+@Data
 public class ExperimentConfigurationResponse {
-    public Map<String, ExperimentConfiguration> experiments;
-
-    @Override
-    public String toString() {
-       return "[Experiments: " + experiments.toString() + "]";
-    }
+    private Map<String, ExperimentConfiguration> flags;
 }

--- a/src/main/java/com/eppo/sdk/dto/Rule.java
+++ b/src/main/java/com/eppo/sdk/dto/Rule.java
@@ -2,14 +2,13 @@ package com.eppo.sdk.dto;
 
 import java.util.List;
 
+import lombok.Data;
+
 /**
  * Rule Class
  */
+@Data
 public class Rule {
-    public List<Condition> conditions;
-
-    @Override
-    public String toString() {
-        return "[Conditions: " + conditions + "]";
-    }
+    private String allocationKey;
+    private List<Condition> conditions;
 }

--- a/src/main/java/com/eppo/sdk/dto/Variation.java
+++ b/src/main/java/com/eppo/sdk/dto/Variation.java
@@ -1,14 +1,12 @@
 package com.eppo.sdk.dto;
 
+import lombok.Data;
+
 /**
  * Experiment's Variation Class
  */
+@Data
 public class Variation {
-    public String name;
-    public ShardRange shardRange;
-
-    @Override
-    public String toString() {
-        return "[Name: " + name + "| ShareRange: " + shardRange.toString() + "]";
-    }
+    private EppoValue value;
+    private ShardRange shardRange;
 }

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -96,7 +96,7 @@ public class ConfigurationStore {
                 .fetchExperimentConfiguration();
 
         if (!response.isEmpty()) {
-            for (Map.Entry<String, ExperimentConfiguration> entry : response.get().experiments.entrySet()) {
+            for (Map.Entry<String, ExperimentConfiguration> entry : response.get().getFlags().entrySet()) {
                 this.setExperimentConfiguration(entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/com/eppo/sdk/helpers/RuleValidator.java
+++ b/src/main/java/com/eppo/sdk/helpers/RuleValidator.java
@@ -7,6 +7,7 @@ import com.eppo.sdk.dto.Condition;
 import com.eppo.sdk.dto.Rule;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -86,6 +87,25 @@ public class RuleValidator {
     }
 
     /**
+     * This function is used to check if any rule is matched
+     *
+     * @param subjectAttributes
+     * @param rules
+     * @return
+     */
+    public static Optional<Rule> findMatchingRule(
+            SubjectAttributes subjectAttributes,
+            List<Rule> rules
+    ) {
+        for (Rule rule : rules) {
+            if (RuleValidator.matchesRule(subjectAttributes, rule)) {
+                return Optional.of(rule);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
      * This function is used to check if rule is matched
      *
      * @param subjectAttributes
@@ -97,7 +117,7 @@ public class RuleValidator {
             SubjectAttributes subjectAttributes,
             Rule rule
     ) throws InvalidSubjectAttribute {
-        List<Boolean> conditionEvaluations = RuleValidator.evaluateRuleConditions(subjectAttributes, rule.conditions);
+        List<Boolean> conditionEvaluations = RuleValidator.evaluateRuleConditions(subjectAttributes, rule.getConditions());
         return !conditionEvaluations.contains(false);
     }
 

--- a/src/main/java/com/eppo/sdk/helpers/RuleValidator.java
+++ b/src/main/java/com/eppo/sdk/helpers/RuleValidator.java
@@ -72,26 +72,6 @@ public class RuleValidator {
      * @param subjectAttributes
      * @param rules
      * @return
-     * @throws InvalidSubjectAttribute
-     */
-    public static boolean matchesAnyRule(
-            SubjectAttributes subjectAttributes,
-            List<Rule> rules
-    ) throws InvalidSubjectAttribute {
-        for (Rule rule : rules) {
-            if (RuleValidator.matchesRule(subjectAttributes, rule)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * This function is used to check if any rule is matched
-     *
-     * @param subjectAttributes
-     * @param rules
-     * @return
      */
     public static Optional<Rule> findMatchingRule(
             SubjectAttributes subjectAttributes,

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -128,7 +128,7 @@ public class EppoClientTest {
   }
 
   private static String getMockRandomizedAssignmentResponse() {
-    File mockRacResponse = new File("src/test/resources/rac-experiments.json");
+    File mockRacResponse = new File("src/test/resources/rac-experiments-v2.json");
     try {
     return FileUtils.readFileToString(mockRacResponse, "UTF8");
     } catch (Exception e) {

--- a/src/test/java/com/eppo/sdk/deserializer/EppoValueDeserializerTest.java
+++ b/src/test/java/com/eppo/sdk/deserializer/EppoValueDeserializerTest.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class SingleValue<T> {
     public T value;
 }

--- a/src/test/java/com/eppo/sdk/helpers/RuleValidatorTest.java
+++ b/src/test/java/com/eppo/sdk/helpers/RuleValidatorTest.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,12 +12,12 @@ class RuleValidatorTest {
 
     public Rule createRule(List<Condition> conditions) {
         final Rule rule = new Rule();
-        rule.conditions = conditions;
+        rule.setConditions(conditions);
         return rule;
     }
 
     public void addConditionToRule(Rule rule, Condition condition) {
-        rule.conditions.add(condition);
+        rule.getConditions().add(condition);
     }
 
     public void addNumericConditionToRule(Rule rule) {
@@ -78,7 +76,7 @@ class RuleValidatorTest {
         subjectAttributes.put("price", EppoValue.valueOf("30"));
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() with empty conditions")
+    @DisplayName("findMatchingRule() with empty conditions")
     @Test
     void testMatchesAnyRuleWithEmptyConditions() {
         List<Rule> rules = new ArrayList<>();
@@ -87,20 +85,20 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         addNameToSubjectAttribute(subjectAttributes);
 
-        Assertions.assertTrue(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertEquals(ruleWithEmptyConditions, RuleValidator.findMatchingRule(subjectAttributes, rules).get());
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() with empty rules")
+    @DisplayName("findMatchingRule() with empty rules")
     @Test
     void testMatchesAnyRuleWithEmptyRules() {
         List<Rule> rules = new ArrayList<>();
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         addNameToSubjectAttribute(subjectAttributes);
 
-        Assertions.assertFalse(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() when no rule matches")
+    @DisplayName("findMatchingRule() when no rule matches")
     @Test
     void testMatchesAnyRuleWhenNoRuleMatches() {
         List<Rule> rules = new ArrayList<>();
@@ -111,10 +109,10 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         addPriceToSubjectAttribute(subjectAttributes);
 
-        Assertions.assertFalse(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() when rule matches")
+    @DisplayName("findMatchingRule() when rule matches")
     @Test
     void testMatchesAnyRuleWhenRuleMatches() {
         List<Rule> rules = new ArrayList<>();
@@ -125,10 +123,10 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         subjectAttributes.put("price", EppoValue.valueOf(15));
 
-        Assertions.assertTrue(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertEquals(rule, RuleValidator.findMatchingRule(subjectAttributes, rules).get());
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() throw InvalidSubjectAttribute")
+    @DisplayName("findMatchingRule() throw InvalidSubjectAttribute")
     @Test
     void testMatchesAnyRuleWhenThrowInvalidSubjectAttribute() {
         List<Rule> rules = new ArrayList<>();
@@ -140,10 +138,10 @@ class RuleValidatorTest {
         subjectAttributes.put("price", EppoValue.valueOf("abcd"));
 
 
-        assertFalse(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() with regex condition")
+    @DisplayName("findMatchingRule() with regex condition")
     @Test
     void testMatchesAnyRuleWithRegexCondition() {
         List<Rule> rules = new ArrayList<>();
@@ -154,10 +152,10 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         subjectAttributes.put("match", EppoValue.valueOf("abcd"));
 
-        Assertions.assertTrue(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertEquals(rule, RuleValidator.findMatchingRule(subjectAttributes, rules).get());
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() with regex condition not matched")
+    @DisplayName("findMatchingRule() with regex condition not matched")
     @Test
     void testMatchesAnyRuleWithRegexConditionNotMatched() {
         List<Rule> rules = new ArrayList<>();
@@ -168,10 +166,10 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         subjectAttributes.put("match", EppoValue.valueOf("123"));
 
-        Assertions.assertFalse(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() with not oneOf rule")
+    @DisplayName("findMatchingRule() with not oneOf rule")
     @Test
     void testMatchesAnyRuleWithNotOneOfRule() {
         List<Rule> rules = new ArrayList<>();
@@ -182,10 +180,10 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         subjectAttributes.put("oneOf", EppoValue.valueOf("value3"));
 
-        Assertions.assertTrue(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertEquals(rule, RuleValidator.findMatchingRule(subjectAttributes, rules).get());
     }
 
-    @DisplayName("Text RuleValidator.matchesAnyRule() with not oneOf rule not passed")
+    @DisplayName("findMatchingRule() with not oneOf rule not passed")
     @Test
     void testMatchesAnyRuleWithNotOneOfRuleNotPassed() {
         List<Rule> rules = new ArrayList<>();
@@ -196,7 +194,7 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         subjectAttributes.put("oneOf", EppoValue.valueOf("value1"));
 
-        Assertions.assertFalse(RuleValidator.matchesAnyRule(subjectAttributes, rules));
+        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
     }
 
 }

--- a/src/test/java/com/eppo/sdk/helpers/ShardTest.java
+++ b/src/test/java/com/eppo/sdk/helpers/ShardTest.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class ShardTest {
 
     ShardRange createShardRange(int start, int end) {


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes Eppo-exp/eppo#4711

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Design Doc: https://www.notion.so/eppo/Feature-Flagging-API-Design-d768a09de1194cebb04ef8af157fda57

## Description
[//]: # (Describe your changes in detail)

Updated the `getAssignment` logic to use the **allocation** (variations + exposure) for the matched targeting rule. The API response inserts a default rule that always matches if the experiment does not have any rules.

See the above design doc for details

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

- Updated the e2e tests to use new test data for the V2 RAC response.
- Tested using the SDK from sample code

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
