### PR TITLE
Don't fail on unknown properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
+++ b/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
@@ -1,5 +1,6 @@
 package com.eppo.sdk.helpers;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ import java.util.Optional;
  */
 @Slf4j
 public class ExperimentConfigurationRequestor {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private EppoHttpClient eppoHttpClient;
 
     public ExperimentConfigurationRequestor(EppoHttpClient eppoHttpClient) {
@@ -35,8 +37,7 @@ public class ExperimentConfigurationRequestor {
             HttpResponse<String> response = this.eppoHttpClient.get(Constants.RAC_ENDPOINT);
             int statusCode = response.statusCode();
             if (statusCode == 200) {
-                ObjectMapper objectMapper = new ObjectMapper();
-                config = objectMapper.readValue(response.body(), ExperimentConfigurationResponse.class);
+                config = OBJECT_MAPPER.readValue(response.body(), ExperimentConfigurationResponse.class);
             }
             if (statusCode == 401) { // unauthorized - invalid API key
                 throw new InvalidApiKeyException("Unauthorized: invalid Eppo API key.");


### PR DESCRIPTION
New properties in the API response should not cause the SDK deserialization to fail.