### PR TITLE
Change log level used when config fails to fetch due to timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
+++ b/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
@@ -43,7 +43,7 @@ public class ExperimentConfigurationRequestor {
                 throw new InvalidApiKeyException("Unauthorized: invalid Eppo API key.");
             }
         } catch (HttpTimeoutException e) { // non-fatal error
-            log.error("Request time out while fetching experiment configurations: " + e.getMessage(), e);
+            log.warn("Request time out while fetching experiment configurations: " + e.getMessage());
         } catch (InvalidApiKeyException e) {
             throw e;
         } catch (Exception e) { // fatal error that will stop the polling process


### PR DESCRIPTION
### Description
A log level of `error` (especially with a full stack trace) can pollute error monitoring systems with messages related to a non-fatal error. Requested by a customer. 