### PR TITLE
Continue polling process for all non-API key related exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
+++ b/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
@@ -42,12 +42,10 @@ public class ExperimentConfigurationRequestor {
             if (statusCode == 401) { // unauthorized - invalid API key
                 throw new InvalidApiKeyException("Unauthorized: invalid Eppo API key.");
             }
-        } catch (HttpTimeoutException e) { // non-fatal error
-            log.warn("Request time out while fetching experiment configurations: " + e.getMessage());
         } catch (InvalidApiKeyException e) {
             throw e;
-        } catch (Exception e) { // fatal error that will stop the polling process
-            throw new NetworkException("Unable to Fetch Experiment Configuration: " + e.getMessage());
+        } catch (Exception e) {
+            log.warn("Unable to Fetch Experiment Configuration: " + e.getMessage());
         }
 
         return Optional.ofNullable(config);


### PR DESCRIPTION
Only stop the polling process if an API key related error occurs. 