### PR TITLE
fixed pushing workflow

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -15,6 +15,8 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
       - name: 'Set up GCP SDK for downloading test data'
         uses: 'google-github-actions/setup-gcloud@v0'
       - name: Download test data
@@ -24,6 +26,7 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish package
         run: mvn nexus-staging:release
         env:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build: test-data
 	mvn --batch-mode --update-snapshots package
 
 ## test-data
-testDataDir := src/test/resources/
+testDataDir := src/test/resources
 tempDir := ${testDataDir}/temp
 gitDataDir := ${tempDir}/sdk-test-data
 branchName := main


### PR DESCRIPTION
Currently, the publish Github workflow is now working because of 
- gpg key not added

Added the gpg private key and paraphase. 