### PR TITLE
Added allocation key in the assignment logging event data

### DIFF
--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -17,6 +17,7 @@ import com.eppo.sdk.helpers.CacheHelper;
 import com.eppo.sdk.helpers.ConfigurationStore;
 import com.eppo.sdk.helpers.EppoHttpClient;
 import com.eppo.sdk.helpers.ExperimentConfigurationRequestor;
+import com.eppo.sdk.helpers.ExperimentHelper;
 import com.eppo.sdk.helpers.FetchConfigurationsTask;
 import com.eppo.sdk.helpers.InputValidator;
 import com.eppo.sdk.helpers.RuleValidator;
@@ -92,7 +93,8 @@ public class EppoClient {
         }
 
         // Check if in experiment sample
-        Allocation allocation = configuration.getAllocation(rule.get().getAllocationKey());
+        String allocationKey = rule.get().getAllocationKey();
+        Allocation allocation = configuration.getAllocation(allocationKey);
         if (!this.isInExperimentSample(subjectKey, flagKey, configuration.getSubjectShards(),
                 allocation.getPercentExposure())) {
             log.info("[Eppo SDK] No assigned variation. The subject is not part of the sample population");
@@ -104,9 +106,12 @@ public class EppoClient {
                 allocation.getVariations());
 
         try {
+            String experimentKey = ExperimentHelper.generateKey(flagKey, allocationKey);
             this.eppoClientConfig.getAssignmentLogger()
                     .logAssignment(new AssignmentLogData(
+                            experimentKey,
                             flagKey,
+                            allocationKey,
                             assignedVariation.getTypedValue().stringValue(),
                             subjectKey,
                             subjectAttributes));

--- a/src/main/java/com/eppo/sdk/dto/AssignmentLogData.java
+++ b/src/main/java/com/eppo/sdk/dto/AssignmentLogData.java
@@ -7,13 +7,26 @@ import java.util.Date;
  */
 public class AssignmentLogData {
     public String experiment;
+
+    public String featureFlag;
+
+    public String allocation;
     public String variation;
     public Date timestamp;
     public String subject;
     public SubjectAttributes subjectAttributes;
 
-    public AssignmentLogData(String experiment, String variation, String subject, SubjectAttributes subjectAttributes) {
+    public AssignmentLogData(
+            String experiment,
+            String featureFlag,
+            String allocation,
+            String variation,
+            String subject,
+            SubjectAttributes subjectAttributes
+    ) {
         this.experiment = experiment;
+        this.featureFlag = featureFlag;
+        this.allocation = allocation;
         this.variation = variation;
         this.timestamp = new Date();
         this.subject = subject;

--- a/src/main/java/com/eppo/sdk/dto/AssignmentLogData.java
+++ b/src/main/java/com/eppo/sdk/dto/AssignmentLogData.java
@@ -7,9 +7,7 @@ import java.util.Date;
  */
 public class AssignmentLogData {
     public String experiment;
-
     public String featureFlag;
-
     public String allocation;
     public String variation;
     public Date timestamp;

--- a/src/main/java/com/eppo/sdk/helpers/ExperimentHelper.java
+++ b/src/main/java/com/eppo/sdk/helpers/ExperimentHelper.java
@@ -1,0 +1,12 @@
+package com.eppo.sdk.helpers;
+
+import java.util.Base64;
+
+public class ExperimentHelper {
+    static public String generateKey(
+            String flagKey,
+            String allocationKey
+    ) {
+        return flagKey + '-' + Base64.getEncoder().encodeToString(allocationKey.getBytes());
+    }
+}

--- a/src/main/java/com/eppo/sdk/helpers/ExperimentHelper.java
+++ b/src/main/java/com/eppo/sdk/helpers/ExperimentHelper.java
@@ -1,12 +1,10 @@
 package com.eppo.sdk.helpers;
 
-import java.util.Base64;
-
 public class ExperimentHelper {
     static public String generateKey(
             String flagKey,
             String allocationKey
     ) {
-        return flagKey + '-' + Base64.getEncoder().encodeToString(allocationKey.getBytes());
+        return flagKey + '-' + allocationKey;
     }
 }


### PR DESCRIPTION
Made below changes in the code.
- Added helper class `ExperimentHelper` to generate experiment key
- Modified the `AssignmentLogData` dto class, added two new field `featureFlag` and `allocation`.
- Initialise `featureFlag` and `allocation` with feature flag key and allocation key respectively while calling assignment log callback.