### PR TITLE
fix makefile test-data on github actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,20 +29,18 @@ build: test-data
 	mvn --batch-mode --update-snapshots package
 
 ## test-data
-testDataDir := src/test/resources
-tempDir := ${testDataDir}/temp
-gitDataDir := ${tempDir}/sdk-test-data
+testDataDir := src/test/resources/
+tempDir := ${testDataDir}temp/
+gitDataDir := ${tempDir}sdk-test-data/
 branchName := main
 githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
 .PHONY: test-data
 test-data: 
 	rm -rf $(testDataDir)
 	mkdir -p $(tempDir)
-	cd ${tempDir} \
-	    && git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} \
-	    && rm -rf RepoName/.git/
-	cp ${gitDataDir}/rac-experiments-v3.json ${testDataDir}
-	cp -r ${gitDataDir}/assignment-v2 ${testDataDir}
+	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
+	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
+	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
 	rm -rf ${tempDir}
 
 .PHONY: test


### PR DESCRIPTION
## motivation

I have seen a few times the `make test-data` action fail on github actions with what seems like the `git clone` command is running async:

```
0s
Run make test-data
rm -rf src/test/resources/
mkdir -p src/test/resources//temp
cd src/test/resources//temp \
    && git clone -b main --depth [1](https://github.com/Eppo-exp/java-server-sdk/actions/runs/6041608861/job/16425318053#step:5:1) --single-branch https://github.com/Eppo-exp/sdk-test-data.git \
    && rm -rf RepoName/.git/
cp src/test/resources//temp/sdk-test-data/rac-experiments-v3.json src/test/resources/
cp -r src/test/resources//temp/sdk-test-data/assignment-v2 src/test/resources/
rm -rf src/test/resources//temp
Cloning into 'sdk-test-data'...
cp: cannot stat 'src/test/resources//temp/sdk-test-data/rac-experiments-v3.json': No such file or directory
make: *** [Makefile:3[9](https://github.com/Eppo-exp/java-server-sdk/actions/runs/6041608861/job/16425318053#step:5:10): test-data] Error 1
Error: Process completed with exit code 2.
```

https://github.com/Eppo-exp/java-server-sdk/actions/runs/6041608861/job/16425318053

## description

I have tried the approach in this PR on another SDK repo where the clone happens as a single command with success.