### PR TITLE
fixed GPG settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
In the current build we were getting below error
```
gpg: signing failed: Inappropriate ioctl for device
```
Added the configuration mentioned in the [doc](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#extra-setup-for-pomxml) to avoid above error