### PR TITLE
add support for getParsedJSONAssignment method returning JsonNode (FF-896)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>2.0.2</version>
+    <version>2.1.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -278,7 +278,7 @@ public class EppoClient {
     }
 
     /**
-     * This function will return json assignment value
+     * This function will return JSON assignment value
      * 
      * @param subjectKey
      * @param experimentKey
@@ -292,7 +292,7 @@ public class EppoClient {
     }
 
     /**
-     * This function will return json string assignment value without passing
+     * This function will return JSON assignment value without passing
      * subjectAttributes
      * 
      * @param subjectKey

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -22,6 +22,7 @@ import com.eppo.sdk.helpers.FetchConfigurationsTask;
 import com.eppo.sdk.helpers.InputValidator;
 import com.eppo.sdk.helpers.RuleValidator;
 import com.eppo.sdk.helpers.Shard;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,8 +61,7 @@ public class EppoClient {
     private Optional<EppoValue> getAssignmentValue(
             String subjectKey,
             String flagKey,
-            SubjectAttributes subjectAttributes
-    ) {
+            SubjectAttributes subjectAttributes) {
         // Validate Input Values
         InputValidator.validateNotBlank(subjectKey, "Invalid argument: subjectKey cannot be blank");
         InputValidator.validateNotBlank(flagKey, "Invalid argument: flagKey cannot be blank");
@@ -142,6 +142,8 @@ public class EppoClient {
                 return Optional.of(value.get().boolValue());
             case NUMBER:
                 return Optional.of(value.get().doubleValue());
+            case JSON_NODE:
+                return Optional.of(value.get().jsonNodeValue());
             default:
                 return Optional.of(value.get().stringValue());
         }
@@ -258,7 +260,7 @@ public class EppoClient {
      * @param subjectAttributes
      * @return
      */
-    public Optional<String> getJSONAssignment(String subjectKey, String experimentKey,
+    public Optional<String> getJSONStringAssignment(String subjectKey, String experimentKey,
             SubjectAttributes subjectAttributes) {
         return this.getStringAssignment(subjectKey, experimentKey, subjectAttributes);
     }
@@ -271,8 +273,34 @@ public class EppoClient {
      * @param experimentKey
      * @return
      */
-    public Optional<String> getJSONAssignment(String subjectKey, String experimentKey) {
-        return this.getJSONAssignment(subjectKey, experimentKey, new SubjectAttributes());
+    public Optional<String> getJSONStringAssignment(String subjectKey, String experimentKey) {
+        return this.getJSONStringAssignment(subjectKey, experimentKey, new SubjectAttributes());
+    }
+
+    /**
+     * This function will return json assignment value
+     * 
+     * @param subjectKey
+     * @param experimentKey
+     * @param subjectAttributes
+     * @return
+     */
+    public Optional<JsonNode> getParsedJSONAssignment(String subjectKey, String experimentKey,
+            SubjectAttributes subjectAttributes) {
+        return (Optional<JsonNode>) this.getTypedAssignment(subjectKey, experimentKey, EppoValueType.JSON_NODE,
+                subjectAttributes);
+    }
+
+    /**
+     * This function will return json string assignment value without passing
+     * subjectAttributes
+     * 
+     * @param subjectKey
+     * @param experimentKey
+     * @return
+     */
+    public Optional<JsonNode> getParsedJSONAssignment(String subjectKey, String experimentKey) {
+        return this.getParsedJSONAssignment(subjectKey, experimentKey, new SubjectAttributes());
     }
 
     /**


### PR DESCRIPTION
## description

note to reviewers: the diff of `EppoClientTest.java` is a little strange reviewing side by side please take care.

## testing

unit tests access json via the parsed method in order to exercise both the `JsonNode` and `String` return types.