### PR TITLE
add graceful mode by default that does not throw exceptions (FF-949)

### DIFF
--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -57,7 +57,6 @@ public class EppoClient {
      * @param flagKey
      * @param subjectAttributes
      * @return
-     * @throws ConfigurationNotFoundException
      */
     protected Optional<EppoValue> getAssignmentValue(
             String subjectKey,

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -59,7 +59,7 @@ public class EppoClient {
      * @return
      * @throws ConfigurationNotFoundException
      */
-    private Optional<EppoValue> getAssignmentValue(
+    protected Optional<EppoValue> getAssignmentValue(
             String subjectKey,
             String flagKey,
             SubjectAttributes subjectAttributes) {
@@ -152,6 +152,7 @@ public class EppoClient {
         } catch (Exception e) {
             // if graceful mode
             if (this.eppoClientConfig.isGracefulMode()) {
+                log.warn("[Eppo SDK] Error getting assignment value: " + e.getMessage());
                 return Optional.empty();
             }
             throw e;

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -57,6 +57,7 @@ public class EppoClient {
      * @param flagKey
      * @param subjectAttributes
      * @return
+     * @throws ConfigurationNotFoundException
      */
     private Optional<EppoValue> getAssignmentValue(
             String subjectKey,
@@ -132,20 +133,28 @@ public class EppoClient {
      */
     private Optional<?> getTypedAssignment(String subjectKey, String experimentKey, EppoValueType type,
             SubjectAttributes subjectAttributes) {
-        Optional<EppoValue> value = this.getAssignmentValue(subjectKey, experimentKey, subjectAttributes);
-        if (value.isEmpty()) {
-            return Optional.empty();
-        }
+        try {
+            Optional<EppoValue> value = this.getAssignmentValue(subjectKey, experimentKey, subjectAttributes);
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
 
-        switch (type) {
-            case BOOLEAN:
-                return Optional.of(value.get().boolValue());
-            case NUMBER:
-                return Optional.of(value.get().doubleValue());
-            case JSON_NODE:
-                return Optional.of(value.get().jsonNodeValue());
-            default:
-                return Optional.of(value.get().stringValue());
+            switch (type) {
+                case BOOLEAN:
+                    return Optional.of(value.get().boolValue());
+                case NUMBER:
+                    return Optional.of(value.get().doubleValue());
+                case JSON_NODE:
+                    return Optional.of(value.get().jsonNodeValue());
+                default:
+                    return Optional.of(value.get().stringValue());
+            }
+        } catch (Exception e) {
+            // if graceful mode
+            if (this.eppoClientConfig.isGracefulMode()) {
+                return Optional.empty();
+            }
+            throw e;
         }
     }
 

--- a/src/main/java/com/eppo/sdk/dto/EppoClientConfig.java
+++ b/src/main/java/com/eppo/sdk/dto/EppoClientConfig.java
@@ -15,4 +15,11 @@ public class EppoClientConfig {
     @Builder.Default
     private String baseURL = Constants.DEFAULT_BASE_URL;
     private IAssignmentLogger assignmentLogger;
+
+    /**
+     * When set to true, the client will not throw an exception when it encounters
+     * an error.
+     */
+    @Builder.Default
+    private boolean isGracefulMode = true;
 }

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -20,8 +20,7 @@ public class ConfigurationStore {
 
     public ConfigurationStore(
             Cache<String, ExperimentConfiguration> experimentConfigurationCache,
-            ExperimentConfigurationRequestor experimentConfigurationRequestor
-    ) {
+            ExperimentConfigurationRequestor experimentConfigurationRequestor) {
         this.experimentConfigurationRequestor = experimentConfigurationRequestor;
         this.experimentConfigurationCache = experimentConfigurationCache;
     }
@@ -35,13 +34,11 @@ public class ConfigurationStore {
      */
     public final static ConfigurationStore init(
             Cache<String, ExperimentConfiguration> experimentConfigurationCache,
-            ExperimentConfigurationRequestor experimentConfigurationRequestor
-    ) {
+            ExperimentConfigurationRequestor experimentConfigurationRequestor) {
         if (ConfigurationStore.instance == null) {
             ConfigurationStore.instance = new ConfigurationStore(
                     experimentConfigurationCache,
-                    experimentConfigurationRequestor
-            );
+                    experimentConfigurationRequestor);
         }
         instance.experimentConfigurationCache.clear();
         return ConfigurationStore.instance;
@@ -71,12 +68,10 @@ public class ConfigurationStore {
      *
      * @param key
      * @return
-     * @throws NetworkException
-     * @throws NetworkRequestNotAllowed
      * @throws ExperimentConfigurationNotFound
      */
     public ExperimentConfiguration getExperimentConfiguration(String key)
-            throws NetworkException, NetworkRequestNotAllowed, ExperimentConfigurationNotFound {
+            throws ExperimentConfigurationNotFound {
         try {
             return this.experimentConfigurationCache.get(key);
         } catch (Exception e) {

--- a/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
+++ b/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
@@ -8,10 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import com.eppo.sdk.constants.Constants;
 import com.eppo.sdk.dto.ExperimentConfigurationResponse;
 import com.eppo.sdk.exception.InvalidApiKeyException;
-import com.eppo.sdk.exception.NetworkException;
 
 import java.net.http.HttpResponse;
-import java.net.http.HttpTimeoutException;
 import java.util.Optional;
 
 /**
@@ -19,7 +17,8 @@ import java.util.Optional;
  */
 @Slf4j
 public class ExperimentConfigurationRequestor {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private EppoHttpClient eppoHttpClient;
 
     public ExperimentConfigurationRequestor(EppoHttpClient eppoHttpClient) {

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
+import java.util.Optional;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -172,7 +172,18 @@ public class EppoClientTest {
     doThrow(new ExperimentConfigurationNotFound("Exception thrown by mock")).when(spyClient)
         .getAssignmentValue(anyString(),
             anyString(), any(SubjectAttributes.class));
+
+    assertDoesNotThrow(() -> spyClient.getBooleanAssignment("subject1", "experiment1"));
+    assertDoesNotThrow(() -> spyClient.getDoubleAssignment("subject1", "experiment1"));
+    assertDoesNotThrow(() -> spyClient.getParsedJSONAssignment("subject1", "experiment1"));
+    assertDoesNotThrow(() -> spyClient.getJSONStringAssignment("subject1", "experiment1"));
     assertDoesNotThrow(() -> spyClient.getStringAssignment("subject1", "experiment1"));
+
+    assertEquals(Optional.empty(), spyClient.getBooleanAssignment("subject1", "experiment1"));
+    assertEquals(Optional.empty(), spyClient.getDoubleAssignment("subject1", "experiment1"));
+    assertEquals(Optional.empty(), spyClient.getParsedJSONAssignment("subject1", "experiment1"));
+    assertEquals(Optional.empty(), spyClient.getJSONStringAssignment("subject1", "experiment1"));
+    assertEquals(Optional.empty(), spyClient.getStringAssignment("subject1", "experiment1"));
   }
 
   @Test()
@@ -196,6 +207,14 @@ public class EppoClientTest {
     doThrow(new ExperimentConfigurationNotFound("Exception thrown by mock")).when(spyClient).getAssignmentValue(
         anyString(),
         anyString(), any(SubjectAttributes.class));
+
+    assertThrows(ExperimentConfigurationNotFound.class,
+        () -> spyClient.getBooleanAssignment("subject1", "experiment1"));
+    assertThrows(ExperimentConfigurationNotFound.class, () -> spyClient.getDoubleAssignment("subject1", "experiment1"));
+    assertThrows(ExperimentConfigurationNotFound.class,
+        () -> spyClient.getParsedJSONAssignment("subject1", "experiment1"));
+    assertThrows(ExperimentConfigurationNotFound.class,
+        () -> spyClient.getJSONStringAssignment("subject1", "experiment1"));
     assertThrows(ExperimentConfigurationNotFound.class, () -> spyClient.getStringAssignment("subject1", "experiment1"));
   }
 

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -1,6 +1,12 @@
 package com.eppo.sdk;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,6 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.eppo.sdk.dto.*;
+import com.eppo.sdk.exception.ExperimentConfigurationNotFound;
 import com.eppo.sdk.helpers.Converter;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
@@ -19,6 +26,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeType;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -141,6 +149,54 @@ public class EppoClientTest {
   @AfterEach
   void teardown() {
     this.mockServer.stop();
+  }
+
+  @Test()
+  void testGracefulModeOn() {
+    EppoClientConfig config = EppoClientConfig.builder()
+        .apiKey("mock-api-key")
+        .baseURL("http://localhost:4001")
+        .isGracefulMode(true)
+        .assignmentLogger(new IAssignmentLogger() {
+          @Override
+          public void logAssignment(AssignmentLogData logData) {
+            // Auto-generated method stub
+          }
+        })
+        .build();
+    EppoClient.init(config);
+    EppoClient realClient = EppoClient.getInstance();
+
+    EppoClient spyClient = spy(realClient);
+
+    doThrow(new ExperimentConfigurationNotFound("Exception thrown by mock")).when(spyClient)
+        .getAssignmentValue(anyString(),
+            anyString(), any(SubjectAttributes.class));
+    assertDoesNotThrow(() -> spyClient.getStringAssignment("subject1", "experiment1"));
+  }
+
+  @Test()
+  void testGracefulModeOff() {
+    EppoClientConfig config = EppoClientConfig.builder()
+        .apiKey("mock-api-key")
+        .baseURL("http://localhost:4001")
+        .isGracefulMode(false)
+        .assignmentLogger(new IAssignmentLogger() {
+          @Override
+          public void logAssignment(AssignmentLogData logData) {
+            // Auto-generated method stub
+          }
+        })
+        .build();
+    EppoClient.init(config);
+    EppoClient realClient = EppoClient.getInstance();
+
+    EppoClient spyClient = spy(realClient);
+
+    doThrow(new ExperimentConfigurationNotFound("Exception thrown by mock")).when(spyClient).getAssignmentValue(
+        anyString(),
+        anyString(), any(SubjectAttributes.class));
+    assertThrows(ExperimentConfigurationNotFound.class, () -> spyClient.getStringAssignment("subject1", "experiment1"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
The default SDK behavior will be to NOT throw exceptions from any of the public methods; just log to `stderr`.

When building a client configuration customers can choose to disable graceful mode, such as for development and testing.

### question

In our javascript commons we added `try/catch` to all top level functions - should we keep that behavior here too for consistency? https://github.com/Eppo-exp/js-client-sdk-common/pull/16