### PR TITLE
FetchConfigurationsTask is more fault tolerant

### DIFF
--- a/src/main/java/com/eppo/sdk/helpers/FetchConfigurationsTask.java
+++ b/src/main/java/com/eppo/sdk/helpers/FetchConfigurationsTask.java
@@ -4,8 +4,10 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
+@Slf4j
 public class FetchConfigurationsTask extends TimerTask {
 
   private ConfigurationStore configurationStore;
@@ -15,8 +17,16 @@ public class FetchConfigurationsTask extends TimerTask {
 
   @Override
   public void run() {
-    configurationStore.fetchAndSetExperimentConfiguration();
-    long delay = this.intervalInMillis - ((long) Math.random() * this.jitterInMillis);
+    // Uncaught runtime exceptions will prevent this task from being rescheduled.
+    // As a result, the SDK will continue functioning using the in-memory cache, but will never attempt
+    // to synchronize with Eppo Cloud again.
+    try {
+      configurationStore.fetchAndSetExperimentConfiguration();
+    } catch (Exception e) {
+      log.error("[Eppo SDK] Error fetching experiment configuration", e);
+    }
+
+    long delay = this.intervalInMillis - (long) (Math.random() * this.jitterInMillis);
     FetchConfigurationsTask nextTask = new FetchConfigurationsTask(configurationStore, timer, intervalInMillis, jitterInMillis);
     timer.schedule(nextTask, delay);
   }


### PR DESCRIPTION
* Have `FetchConfigurationsTask` catch runtime exceptions and log the error
    * Without this change, arbitrary exceptions would prevent tasks from being rescheduled. When this happens the SDK is still _technically_ functional via it's in-memory cache used by the `ConfigurationStore`... but all further communication between the SDK and Eppo Cloud is effectively terminated.
* Fixed an issue calculating jitter
    * `(long) Math.random()` is always cast to `0`. 