### PR TITLE
Add support for java 8 (FF-1572)

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -1,4 +1,5 @@
 name: Test and lint SDK
+
 on:
   pull_request:
     paths:
@@ -7,14 +8,20 @@ on:
 jobs:
   lint-test-sdk:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        java-version: ['8', '11', '17'] # Define the Java versions to test against
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
+      
       - name: 'Set up GCP SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
+      
       - name: Run tests
         run: make test

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
       - name: 'Set up GCP SDK'
         uses: 'google-github-actions/setup-gcloud@v0'

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
         <url>http://github.com/Eppo-exp/java-server-sdk/tree/main</url>
     </scm>
 
-
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>
@@ -34,8 +34,8 @@
 
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -54,6 +54,11 @@
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
             <version>3.9.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.10</version>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>

--- a/src/main/java/com/eppo/sdk/helpers/EppoHttpClient.java
+++ b/src/main/java/com/eppo/sdk/helpers/EppoHttpClient.java
@@ -1,10 +1,11 @@
 package com.eppo.sdk.helpers;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -14,11 +15,18 @@ import java.util.stream.Stream;
  * Eppo Http Client Class
  */
 public class EppoHttpClient {
-    private HttpClient httpClient = HttpClient.newHttpClient();
+
     private Map<String, String> defaultParams = new HashMap<>();
     private String baseURl;
 
     private int requestTimeOutMillis = 3000; // 3 secs
+
+    private RequestConfig config = RequestConfig.custom()
+            .setConnectTimeout(requestTimeOutMillis)
+            .setConnectionRequestTimeout(requestTimeOutMillis)
+            .setSocketTimeout(requestTimeOutMillis).build();
+
+    private HttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
 
     public EppoHttpClient(String apikey, String sdkName, String sdkVersion, String baseURl) {
         this.defaultParams.put("apiKey", apikey);
@@ -61,7 +69,7 @@ public class EppoHttpClient {
      * @return
      * @throws Exception
      */
-    public HttpResponse<String> get(
+    public HttpResponse get(
             String url,
             Map<String, String> params,
             Map<String, String> headers
@@ -75,20 +83,14 @@ public class EppoHttpClient {
 
         // Build URL
         final String newUrl = this.urlBuilder(this.baseURl + url, allParams);
-        HttpRequest.Builder builder = HttpRequest.newBuilder()
-                .GET()
-                .timeout(Duration.ofMillis(requestTimeOutMillis))
-                .uri(new URI(newUrl));
+        HttpGet getRequest = new HttpGet(newUrl);
 
-        // Set Header
+
         for (Map.Entry<String, String> entry : headers.entrySet()) {
-            builder = builder.setHeader(entry.getKey(), entry.getValue());
+            getRequest.setHeader(entry.getKey(), entry.getValue());
         }
 
-        HttpRequest request = builder.build();
-
-        // Make a Request
-        return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        return httpClient.execute(getRequest);
     }
 
     /**
@@ -99,7 +101,7 @@ public class EppoHttpClient {
      * @return
      * @throws Exception
      */
-    public HttpResponse<String> get(String url, Map<String, String> params) throws Exception {
+    public HttpResponse get(String url, Map<String, String> params) throws Exception {
         return this.get(url, params, new HashMap<>());
     }
 
@@ -110,7 +112,7 @@ public class EppoHttpClient {
      * @return
      * @throws Exception
      */
-    public HttpResponse<String> get(String url) throws Exception {
+    public HttpResponse get(String url) throws Exception {
         return this.get(url, new HashMap<>(), new HashMap<>());
     }
 

--- a/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
+++ b/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
@@ -8,8 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import com.eppo.sdk.constants.Constants;
 import com.eppo.sdk.dto.ExperimentConfigurationResponse;
 import com.eppo.sdk.exception.InvalidApiKeyException;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
 
-import java.net.http.HttpResponse;
 import java.util.Optional;
 
 /**
@@ -33,10 +34,10 @@ public class ExperimentConfigurationRequestor {
     public Optional<ExperimentConfigurationResponse> fetchExperimentConfiguration() {
         ExperimentConfigurationResponse config = null;
         try {
-            HttpResponse<String> response = this.eppoHttpClient.get(Constants.RAC_ENDPOINT);
-            int statusCode = response.statusCode();
+            HttpResponse response = this.eppoHttpClient.get(Constants.RAC_ENDPOINT);
+            int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 200) {
-                config = OBJECT_MAPPER.readValue(response.body(), ExperimentConfigurationResponse.class);
+                config = OBJECT_MAPPER.readValue(EntityUtils.toString(response.getEntity()), ExperimentConfigurationResponse.class);
             }
             if (statusCode == 401) { // unauthorized - invalid API key
                 throw new InvalidApiKeyException("Unauthorized: invalid Eppo API key.");


### PR DESCRIPTION
## context

Eppo's customers need support for java 8, which is still a supported version by Oracle until 2023.

## description

* Adds support for java 8
* Converts eppo http client to use `org.apache.http` for broader compatibility
* Adds github tests across multiple versions: 8, 11 and 17
* Publish artifact against java 8