### PR TITLE
add compatibility for java 8

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -1,4 +1,5 @@
 name: Test and lint SDK
+
 on:
   pull_request:
     paths:
@@ -7,14 +8,20 @@ on:
 jobs:
   lint-test-sdk:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        java-version: ['8', '11', '17'] # Define the Java versions to test against
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
+      
       - name: 'Set up GCP SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
+      
       - name: Run tests
         run: make test

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -7,26 +7,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
+
       - name: 'Set up GCP SDK for downloading test data'
         uses: 'google-github-actions/setup-gcloud@v0'
+
       - name: Download test data
         run: make test-data
+
       - name: Deploy package
         run: mvn clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          
       - name: Publish package
         run: mvn nexus-staging:release
         env:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ help: Makefile
 build: test-data
 	mvn --batch-mode --update-snapshots package
 
+docker-compile-java:
+	@docker run --rm -v "$$(pwd)":/usr/src/myapp -w /usr/src/myapp amd64/maven:3.8.2-ibmjava-8-alpine mvn clean compile
+	
 ## test-data
 testDataDir := src/test/resources/
 tempDir := ${testDataDir}temp/

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
 
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -54,6 +54,11 @@
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
             <version>3.9.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.10</version>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
@@ -143,26 +148,26 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <gpgArguments>
-                        <arg>--pinentry-mode</arg>
-                        <arg>loopback</arg>
-                    </gpgArguments>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <version>3.1.0</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--                <configuration>-->
+<!--                    <gpgArguments>-->
+<!--                        <arg>&#45;&#45;pinentry-mode</arg>-->
+<!--                        <arg>loopback</arg>-->
+<!--                    </gpgArguments>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -148,26 +148,26 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-gpg-plugin</artifactId>-->
-<!--                <version>3.1.0</version>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <id>sign-artifacts</id>-->
-<!--                        <phase>verify</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>sign</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--                <configuration>-->
-<!--                    <gpgArguments>-->
-<!--                        <arg>&#45;&#45;pinentry-mode</arg>-->
-<!--                        <arg>loopback</arg>-->
-<!--                    </gpgArguments>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <gpgArguments>
+                        <arg>&#45;&#45;pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -105,10 +105,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
-                    <argLine>
-                        --add-opens java.base/java.lang=ALL-UNNAMED
-                        --add-opens java.base/java.util=ALL-UNNAMED
-                    </argLine>
+                     <!-- No argLine needed for Java 8 -->
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
                 </executions>
                 <configuration>
                     <gpgArguments>
-                        <arg>&#45;&#45;pinentry-mode</arg>
+                        <arg>--pinentry-mode</arg>
                         <arg>loopback</arg>
                     </gpgArguments>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cloud.eppo</groupId>
@@ -15,8 +15,8 @@
 
     <licenses>
         <license>
-        <name>MIT License</name>
-        <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
         </license>
     </licenses>
     <developers>
@@ -32,6 +32,48 @@
         <url>http://github.com/Eppo-exp/java-server-sdk/tree/main</url>
     </scm>
 
+    <profiles>
+        <!-- Profile for Java 8 -->
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <!-- Specific configuration for Java 8 -->
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- Profile for Java 11 and above -->
+        <profile>
+            <id>java11plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine> --add-opens java.base/java.lang=ALL-UNNAMED --add-opens
+                                java.base/java.util=ALL-UNNAMED <!-- Add other JVM arguments as
+                                necessary -->
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -46,10 +88,10 @@
             <version>2.14.2</version>
         </dependency>
         <dependency>
-		    <groupId>org.projectlombok</groupId>
-		    <artifactId>lombok</artifactId>
-		    <version>1.18.24</version>
-	    </dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.24</version>
+        </dependency>
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
@@ -86,7 +128,7 @@
             <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
-	<build>
+    <build>
         <testResources>
             <testResource>
                 <directory>src/test/resources</directory>
@@ -100,14 +142,6 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
-                <configuration>
-                     <!-- No argLine needed for Java 8 -->
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -87,7 +87,7 @@ public class EppoClient {
 
         // Find matched rule
         Optional<Rule> rule = RuleValidator.findMatchingRule(subjectAttributes, configuration.getRules());
-        if (rule.isEmpty()) {
+        if (!rule.isPresent()) {
             log.info("[Eppo SDK] No assigned variation. The subject attributes did not match any targeting rules");
             return Optional.empty();
         }
@@ -134,7 +134,7 @@ public class EppoClient {
             SubjectAttributes subjectAttributes) {
         try {
             Optional<EppoValue> value = this.getAssignmentValue(subjectKey, experimentKey, subjectAttributes);
-            if (value.isEmpty()) {
+            if (!value.isPresent()) {
                 return Optional.empty();
             }
 

--- a/src/main/java/com/eppo/sdk/dto/EppoValue.java
+++ b/src/main/java/com/eppo/sdk/dto/EppoValue.java
@@ -4,6 +4,7 @@ import com.eppo.sdk.deserializer.EppoValueDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -107,10 +108,11 @@ public class EppoValue {
     @Override
     public String toString() {
         if (this.isArray()) {
-            return List.of(this.array).toString();
+            // Assuming this.array is an array, use Arrays.asList() for compatibility with Java 8
+            return Arrays.asList(this.array).toString();
         } else if (this.type == EppoValueType.JSON_NODE) {
             return this.node.toString();
         }
-        return this.value;
+            return this.value;
+        }
     }
-}

--- a/src/main/java/com/eppo/sdk/dto/EppoValue.java
+++ b/src/main/java/com/eppo/sdk/dto/EppoValue.java
@@ -113,6 +113,6 @@ public class EppoValue {
         } else if (this.type == EppoValueType.JSON_NODE) {
             return this.node.toString();
         }
-            return this.value;
-        }
+        return this.value;
     }
+}

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -90,7 +90,7 @@ public class ConfigurationStore {
         Optional<ExperimentConfigurationResponse> response = this.experimentConfigurationRequestor
                 .fetchExperimentConfiguration();
 
-        if (!response.isEmpty()) {
+        if (response.isPresent()) {
             for (Map.Entry<String, ExperimentConfiguration> entry : response.get().getFlags().entrySet()) {
                 this.setExperimentConfiguration(entry.getKey(), entry.getValue());
             }

--- a/src/main/java/com/eppo/sdk/helpers/EppoHttpClient.java
+++ b/src/main/java/com/eppo/sdk/helpers/EppoHttpClient.java
@@ -81,21 +81,11 @@ public class EppoHttpClient {
         final String newUrl = this.urlBuilder(this.baseURl + url, allParams);
         HttpGet getRequest = new HttpGet(newUrl);
 
-
-//                .GET()
-//                .timeout(Duration.ofMillis(requestTimeOutMillis))
-//                .uri(new URI(newUrl));
-
-        // Set Header
-
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             getRequest.setHeader(entry.getKey(), entry.getValue());
         }
 
-        HttpResponse response = httpClient.execute(getRequest);
-
-        // Make a Request
-        return response;
+        return httpClient.execute(getRequest);
     }
 
     /**

--- a/src/main/java/com/eppo/sdk/helpers/EppoHttpClient.java
+++ b/src/main/java/com/eppo/sdk/helpers/EppoHttpClient.java
@@ -1,9 +1,13 @@
 package com.eppo.sdk.helpers;
 
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +18,7 @@ import java.util.stream.Stream;
  * Eppo Http Client Class
  */
 public class EppoHttpClient {
-    private HttpClient httpClient = HttpClient.newHttpClient();
+    private HttpClient httpClient = HttpClients.createDefault();
     private Map<String, String> defaultParams = new HashMap<>();
     private String baseURl;
 
@@ -61,7 +65,7 @@ public class EppoHttpClient {
      * @return
      * @throws Exception
      */
-    public HttpResponse<String> get(
+    public HttpResponse get(
             String url,
             Map<String, String> params,
             Map<String, String> headers
@@ -75,20 +79,23 @@ public class EppoHttpClient {
 
         // Build URL
         final String newUrl = this.urlBuilder(this.baseURl + url, allParams);
-        HttpRequest.Builder builder = HttpRequest.newBuilder()
-                .GET()
-                .timeout(Duration.ofMillis(requestTimeOutMillis))
-                .uri(new URI(newUrl));
+        HttpGet getRequest = new HttpGet(newUrl);
+
+
+//                .GET()
+//                .timeout(Duration.ofMillis(requestTimeOutMillis))
+//                .uri(new URI(newUrl));
 
         // Set Header
+
         for (Map.Entry<String, String> entry : headers.entrySet()) {
-            builder = builder.setHeader(entry.getKey(), entry.getValue());
+            getRequest.setHeader(entry.getKey(), entry.getValue());
         }
 
-        HttpRequest request = builder.build();
+        HttpResponse response = httpClient.execute(getRequest);
 
         // Make a Request
-        return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        return response;
     }
 
     /**
@@ -99,7 +106,7 @@ public class EppoHttpClient {
      * @return
      * @throws Exception
      */
-    public HttpResponse<String> get(String url, Map<String, String> params) throws Exception {
+    public HttpResponse get(String url, Map<String, String> params) throws Exception {
         return this.get(url, params, new HashMap<>());
     }
 
@@ -110,7 +117,7 @@ public class EppoHttpClient {
      * @return
      * @throws Exception
      */
-    public HttpResponse<String> get(String url) throws Exception {
+    public HttpResponse get(String url) throws Exception {
         return this.get(url, new HashMap<>(), new HashMap<>());
     }
 

--- a/src/main/java/com/eppo/sdk/helpers/EppoHttpClient.java
+++ b/src/main/java/com/eppo/sdk/helpers/EppoHttpClient.java
@@ -4,7 +4,9 @@ import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
 import java.net.URI;
@@ -18,11 +20,18 @@ import java.util.stream.Stream;
  * Eppo Http Client Class
  */
 public class EppoHttpClient {
-    private HttpClient httpClient = HttpClients.createDefault();
+
     private Map<String, String> defaultParams = new HashMap<>();
     private String baseURl;
 
     private int requestTimeOutMillis = 3000; // 3 secs
+
+    private RequestConfig config = RequestConfig.custom()
+            .setConnectTimeout(requestTimeOutMillis)
+            .setConnectionRequestTimeout(requestTimeOutMillis)
+            .setSocketTimeout(requestTimeOutMillis).build();
+
+    private HttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
 
     public EppoHttpClient(String apikey, String sdkName, String sdkVersion, String baseURl) {
         this.defaultParams.put("apiKey", apikey);
@@ -80,6 +89,7 @@ public class EppoHttpClient {
         // Build URL
         final String newUrl = this.urlBuilder(this.baseURl + url, allParams);
         HttpGet getRequest = new HttpGet(newUrl);
+
 
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             getRequest.setHeader(entry.getKey(), entry.getValue());

--- a/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
+++ b/src/main/java/com/eppo/sdk/helpers/ExperimentConfigurationRequestor.java
@@ -8,8 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import com.eppo.sdk.constants.Constants;
 import com.eppo.sdk.dto.ExperimentConfigurationResponse;
 import com.eppo.sdk.exception.InvalidApiKeyException;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
 
-import java.net.http.HttpResponse;
 import java.util.Optional;
 
 /**
@@ -33,10 +34,10 @@ public class ExperimentConfigurationRequestor {
     public Optional<ExperimentConfigurationResponse> fetchExperimentConfiguration() {
         ExperimentConfigurationResponse config = null;
         try {
-            HttpResponse<String> response = this.eppoHttpClient.get(Constants.RAC_ENDPOINT);
-            int statusCode = response.statusCode();
+            HttpResponse response = this.eppoHttpClient.get(Constants.RAC_ENDPOINT);
+            int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 200) {
-                config = OBJECT_MAPPER.readValue(response.body(), ExperimentConfigurationResponse.class);
+                config = OBJECT_MAPPER.readValue(EntityUtils.toString(response.getEntity()), ExperimentConfigurationResponse.class);
             }
             if (statusCode == 401) { // unauthorized - invalid API key
                 throw new InvalidApiKeyException("Unauthorized: invalid Eppo API key.");

--- a/src/main/java/com/eppo/sdk/helpers/InputValidator.java
+++ b/src/main/java/com/eppo/sdk/helpers/InputValidator.java
@@ -14,7 +14,7 @@ public class InputValidator {
      * @throws InvalidInputException
      */
     public static boolean validateNotBlank(String input, String errorMsg) throws InvalidInputException {
-        if (input.isBlank()) {
+        if (input.trim().isEmpty()) {
             throw new InvalidInputException(errorMsg);
         }
 

--- a/src/test/java/com/eppo/sdk/helpers/RuleValidatorTest.java
+++ b/src/test/java/com/eppo/sdk/helpers/RuleValidatorTest.java
@@ -95,7 +95,7 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         addNameToSubjectAttribute(subjectAttributes);
 
-        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
+        Assertions.assertFalse(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
     }
 
     @DisplayName("findMatchingRule() when no rule matches")
@@ -109,7 +109,7 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         addPriceToSubjectAttribute(subjectAttributes);
 
-        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
+        Assertions.assertFalse(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
     }
 
     @DisplayName("findMatchingRule() when rule matches")
@@ -138,7 +138,7 @@ class RuleValidatorTest {
         subjectAttributes.put("price", EppoValue.valueOf("abcd"));
 
 
-        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
+        Assertions.assertFalse(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
     }
 
     @DisplayName("findMatchingRule() with regex condition")
@@ -166,7 +166,7 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         subjectAttributes.put("match", EppoValue.valueOf("123"));
 
-        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
+        Assertions.assertFalse(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
     }
 
     @DisplayName("findMatchingRule() with not oneOf rule")
@@ -194,7 +194,7 @@ class RuleValidatorTest {
         SubjectAttributes subjectAttributes = new SubjectAttributes();
         subjectAttributes.put("oneOf", EppoValue.valueOf("value1"));
 
-        Assertions.assertTrue(RuleValidator.findMatchingRule(subjectAttributes, rules).isEmpty());
+        Assertions.assertFalse(RuleValidator.findMatchingRule(subjectAttributes, rules).isPresent());
     }
 
 }


### PR DESCRIPTION
## context

Eppo's customers need support for Java 8.

## description

There are certain language support not available in java 8 and libraries that are not available. For compatibility:

* `List.of` replaced with `Arrays.asList`
* `java.net.http` replaced with `org.apache.http`
* `isBlank` replaced with `isPresent`

**support for local development**

It is not possible to install java 8 on apple m-processor machines.

```
 brew install openjdk@8
openjdk@8: The x86_64 architecture is required for this software.
Error: openjdk@8: An unsatisfied requirement failed this build.
```

Created a docker-based compilation to enable developers to more easily contribute:

```
make docker-compile-java
...
[WARNING] /usr/src/myapp/src/main/java/com/eppo/sdk/EppoClient.java: Recompile with -Xlint:unchecked for details.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.622 s
[INFO] Finished at: 2024-02-15T18:42:28Z
[INFO] ------------------------------------------------------------------------
```