### PR TITLE
Latest version of staging plugin and increased timeout

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -5,7 +5,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
Our publish action is hitting a timeout. As a hail mary, I'm updating the latest version of the plugin.
```
Uploaded to ossrh: [https://s01.oss.sonatype.org:443/service/local/staging/deployByRepositoryId/cloudeppo-1026/cloud/eppo/eppo-server-sdk/2.4.1/eppo-server-sdk-2.4.1.jar](https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/cloudeppo-1026/cloud/eppo/eppo-server-sdk/2.4.1/eppo-server-sdk-2.4.1.jar) (83 kB at 187 kB/s)
Uploading to ossrh: [https://s01.oss.sonatype.org:443/service/local/staging/deployByRepositoryId/cloudeppo-1026/cloud/eppo/eppo-server-sdk/2.4.1/eppo-server-sdk-2.4.1.pom](https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/cloudeppo-1026/cloud/eppo/eppo-server-sdk/2.4.1/eppo-server-sdk-2.4.1.pom)
Progress (1): 4.1/8.3 kB
Progress (1): 8.2/8.3 kB
Progress (1): 8.3 kB    
                    
Uploaded to ossrh: [https://s01.oss.sonatype.org:443/service/local/staging/deployByRepositoryId/cloudeppo-1026/cloud/eppo/eppo-server-sdk/2.4.1/eppo-server-sdk-2.4.1.pom](https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/cloudeppo-1026/cloud/eppo/eppo-server-sdk/2.4.1/eppo-server-sdk-2.4.1.pom) (8.3 kB at 15 kB/s)
[INFO]  * Upload of locally staged artifacts finished.
[INFO]  * Closing staging repository with ID "cloudeppo-1026".

Waiting for operation to complete...
..................................................................
Warning:  TIMEOUT after 302.8 s

Error:  Rule failure while trying to close staging repository with ID "cloudeppo-1026".
Error:  
Error:  Nexus Staging Rules Failure Report
Error:  ==================================
Error:  
Error:  
Error:  Cleaning up local stage directory after a Rule failure during close of staging repositories: []
Error:   * Deleting context d81bf862e290c.properties
Error:  Cleaning up remote stage repositories after a Rule failure during close of staging repositories: []
Error:   * Dropping failed staging repository with ID "cloudeppo-1026" (Rule failure during close of staging repositories: []).

Waiting for operation to complete...
................................................................................
Warning:  TIMEOUT after 300.4 s

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12:56 min
[INFO] Finished at: 2024-03-23T01:23:10Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:deploy (injected-nexus-deploy) on project eppo-server-sdk: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:deploy failed: Staging rules failure! -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
Error: Process completed with exit code 1.
##[debug]Finishing: Deploy package
```