### PR TITLE
Update endpoint; separate bandit functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -304,11 +304,12 @@ public class EppoClient {
      */
     public Optional<String> getStringAssignment(String subjectKey, String flagKey,
             EppoAttributes subjectAttributes) {
-        return this.getStringAssignment(subjectKey, flagKey, subjectAttributes, new HashSet<>());
+        Optional<String> typedAssignment = (Optional<String>) this.getTypedAssignment(EppoValueType.STRING, subjectKey, flagKey, subjectAttributes, new HashMap<>());
+        return typedAssignment;
     }
 
     /**
-     * Maps a subject to a variation for a given flag/bandit/experiment.
+     * Maps a subject to a variation for a given flag/experiment that has bandit variation.
      *
      * @param subjectKey identifier of the experiment subject, for example a user ID.
      * @param flagKey flagKey feature flag, bandit, or experiment identifier
@@ -318,22 +319,22 @@ public class EppoClient {
      * @param actions used by bandits to know the actions (potential assignments) available.
      * @return the variation string assigned to the subject, or null if an unrecoverable error was encountered.
      */
-    public Optional<String> getStringAssignment(
-            String subjectKey,
-            String flagKey,
-            EppoAttributes subjectAttributes,
-            Set<String> actions
+    public Optional<String> getBanditAssignment(
+      String subjectKey,
+      String flagKey,
+      EppoAttributes subjectAttributes,
+      Set<String> actions
     ) {
         Map<String, EppoAttributes> actionsWithEmptyAttributes = actions.stream()
-                .collect(Collectors.toMap(
-                        key -> key,
-                        value -> new EppoAttributes()
-                ));
-        return this.getStringAssignment(subjectKey, flagKey, subjectAttributes, actionsWithEmptyAttributes);
+          .collect(Collectors.toMap(
+            key -> key,
+            value -> new EppoAttributes()
+          ));
+        return this.getBanditAssignment(subjectKey, flagKey, subjectAttributes, actionsWithEmptyAttributes);
     }
 
     /**
-     * Maps a subject to a variation for a given flag/bandit/experiment.
+     * Maps a subject to a variation for a given flag/experiment that contains a bandit variation.
      *
      * @param subjectKey identifier of the experiment subject, for example a user ID.
      * @param flagKey flagKey feature flag, bandit, or experiment identifier
@@ -344,11 +345,11 @@ public class EppoClient {
      *                              attributes associated with that option.
      * @return the variation string assigned to the subject, or null if an unrecoverable error was encountered.
      */
-    public Optional<String> getStringAssignment(
-            String subjectKey,
-            String flagKey,
-            EppoAttributes subjectAttributes,
-            Map<String, EppoAttributes> actionsWithAttributes
+    Optional<String> getBanditAssignment(
+      String subjectKey,
+      String flagKey,
+      EppoAttributes subjectAttributes,
+      Map<String, EppoAttributes> actionsWithAttributes
     ) {
         @SuppressWarnings("unchecked")
         Optional<String> typedAssignment = (Optional<String>) this.getTypedAssignment(EppoValueType.STRING, subjectKey, flagKey, subjectAttributes, actionsWithAttributes);

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -345,7 +345,7 @@ public class EppoClient {
      *                              attributes associated with that option.
      * @return the variation string assigned to the subject, or null if an unrecoverable error was encountered.
      */
-    Optional<String> getBanditAssignment(
+    public Optional<String> getBanditAssignment(
       String subjectKey,
       String flagKey,
       EppoAttributes subjectAttributes,

--- a/src/main/java/com/eppo/sdk/constants/Constants.java
+++ b/src/main/java/com/eppo/sdk/constants/Constants.java
@@ -32,7 +32,7 @@ public class Constants {
      */
     public static final String RAC_ENDPOINT = "/randomized_assignment/v3/config";
 
-    public static final String BANDIT_ENDPOINT = "/randomized_assignment/v3/bandits";
+    public static final String BANDIT_ENDPOINT = "/flag-config/v1/bandits";
 
 
     /**

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -138,7 +138,7 @@ public class EppoClientTest {
     );
     String banditResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/bandits-parameters-1.json");
     this.mockServer.stubFor(
-      WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/bandits\\?.*"))
+      WireMock.get(WireMock.urlMatching(".*flag-config/v1/bandits\\?.*"))
         .willReturn(WireMock.okJson(banditResponseJson))
     );
 
@@ -368,7 +368,7 @@ public class EppoClientTest {
     Set<String> banditActions = Stream.of("option1", "option2", "option3").collect(Collectors.toSet());
 
     // Attempt to get a bandit assignment
-    Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
+    Optional<String> stringAssignment = EppoClient.getInstance().getBanditAssignment(
       "subject1",
       "cold-start-bandit-experiment",
       new EppoAttributes(),
@@ -411,7 +411,7 @@ public class EppoClientTest {
     Set<String> banditActions = Stream.of("option1", "option2", "option3").collect(Collectors.toSet());
 
     // Attempt to get a bandit assignment
-    Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
+    Optional<String> stringAssignment = EppoClient.getInstance().getBanditAssignment(
       "subject8",
       "uninitialized-bandit-experiment",
       new EppoAttributes(),
@@ -476,7 +476,7 @@ public class EppoClientTest {
     actionsWithAttributes.put("puma", new EppoAttributes());
 
     // Get our assigned action
-    Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
+    Optional<String> stringAssignment = EppoClient.getInstance().getBanditAssignment(
       "subject2",
       "banner-bandit-experiment",
       subjectAttributes,
@@ -556,7 +556,7 @@ public class EppoClientTest {
     actionAttributes.put("puma", pumaAttributes);
 
     // Get our assigned action
-    Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
+    Optional<String> stringAssignment = EppoClient.getInstance().getBanditAssignment(
       "subject30",
       "banner-bandit-experiment",
       subjectAttributes,
@@ -578,7 +578,7 @@ public class EppoClientTest {
     Set<String> actions = Stream.of("nike", "adidas", "puma").collect(Collectors.toSet());
 
     // Get our assigned action
-    Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
+    Optional<String> stringAssignment = EppoClient.getInstance().getBanditAssignment(
       "subject39",
       "banner-bandit-experiment",
       subjectAttributes,
@@ -605,7 +605,7 @@ public class EppoClientTest {
     subjectAttributes.put("is_account_admin", EppoValue.valueOf(false));
 
     // Attempt to get a bandit assignment
-    Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
+    Optional<String> stringAssignment = EppoClient.getInstance().getBanditAssignment(
             "subject10",
             "cold-start-bandit-experiment",
             subjectAttributes,
@@ -678,7 +678,7 @@ public class EppoClientTest {
     Set<String> banditActions = Stream.of("option1", "option2", "option3").collect(Collectors.toSet());
 
     // Attempt to get a bandit assignment
-    Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
+    Optional<String> stringAssignment = EppoClient.getInstance().getBanditAssignment(
             "subject2",
             "cold-start-bandit",
             new EppoAttributes(),


### PR DESCRIPTION
_Eppo Internal:_ 🎟️ **Ticket:** [FF-1971 - Have bandit use flag-config endpoint](https://linear.app/eppo/issue/FF-1971/have-bandit-use-flag-config-endpoint)

This PR introduces two quality-of-life changes:
1. Update the endpoint the SDK loads bandits from to match where it will soon load the Universal Flag Configuration (UFC)
2. Create dedicated `getBanditAction()` functions to get bandit actions (separating from `getStringAssignment()`)