### PR TITLE
Ingest categorical coefficients as an object (Map)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>2.4.4</version>
+    <version>2.4.5</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/deserializer/BanditsDeserializer.java
+++ b/src/main/java/com/eppo/sdk/deserializer/BanditsDeserializer.java
@@ -112,11 +112,13 @@ public class BanditsDeserializer extends StdDeserializer<Map<String, BanditParam
         categoricalAttributeCoefficientsArrayNode.iterator().forEachRemaining(categoricalAttributeCoefficientsNode -> {
             String attributeKey = categoricalAttributeCoefficientsNode.get("attributeKey").asText();
             Double missingValueCoefficient = categoricalAttributeCoefficientsNode.get("missingValueCoefficient").asDouble();
+
             Map<String, Double> valueCoefficients = new HashMap<>();
-            JsonNode valuesNode = categoricalAttributeCoefficientsNode.get("values");
-            valuesNode.iterator().forEachRemaining(valueNode -> {
-                String value = valueNode.get("value").asText();
-                Double coefficient = valueNode.get("coefficient").asDouble();
+            JsonNode valuesNode = categoricalAttributeCoefficientsNode.get("valueCoefficients");
+            Iterator<Map.Entry<String, JsonNode>> coefficientIterator = valuesNode.fields();
+            coefficientIterator.forEachRemaining(field -> {
+                String value = field.getKey();
+                Double coefficient = field.getValue().asDouble();
                 valueCoefficients.put(value, coefficient);
             });
 

--- a/src/test/resources/bandits/bandits-parameters-1.json
+++ b/src/test/resources/bandits/bandits-parameters-1.json
@@ -24,11 +24,11 @@
             "actionCategoricalCoefficients": [
               {
                 "attributeKey": "loyalty_tier",
-                "values": [
-                  { "value": "gold", "coefficient": 4.5 },
-                  { "value": "silver", "coefficient": 3.2 },
-                  { "value": "bronze", "coefficient": 1.9 }
-                ],
+                "valueCoefficients": {
+                  "gold": 4.5,
+                  "silver": 3.2,
+                  "bronze": 1.9
+                },
                 "missingValueCoefficient": 0.0
               }
             ],
@@ -42,10 +42,10 @@
             "subjectCategoricalCoefficients": [
               {
                 "attributeKey": "gender_identity",
-                "values": [
-                  { "value": "female", "coefficient": 0.5 },
-                  { "value": "male", "coefficient": -0.5 }
-                ],
+                "valueCoefficients": {
+                  "female": 0.5,
+                  "male": -0.5
+                },
                 "missingValueCoefficient": 2.3
               }
             ]
@@ -63,10 +63,10 @@
             "actionCategoricalCoefficients": [
               {
                 "attributeKey": "purchased_last_30_days",
-                "values": [
-                  { "value": "true", "coefficient": 9.0 },
-                  { "value": "false", "coefficient": 0.0 }
-                ],
+                "valueCoefficients": {
+                  "true": 9.0,
+                  "false": 0.0
+                },
                 "missingValueCoefficient": 0.0
               }
             ],
@@ -74,10 +74,10 @@
             "subjectCategoricalCoefficients": [
               {
                 "attributeKey": "gender_identity",
-                "values": [
-                  { "value": "female", "coefficient": 0.0 },
-                  { "value": "male", "coefficient": 0.3 }
-                ],
+                "valueCoefficients": {
+                  "female": 0.0,
+                  "male": 0.3
+                },
                 "missingValueCoefficient": 0.45
               }
             ]


### PR DESCRIPTION
_Eppo Iternal:_
🎟️ **Ticket:** [FF-2218 - JS SDK - local and chrome storage caches should be isolated per-API key](https://linear.app/eppo/issue/FF-2230/js-sdk-local-and-chrome-storage-caches-should-be-isolated-per-api-key)

The Eppo servers are changing the way categorical attribute coefficients are transmitted to be an object (mapping) instead of an array (list of keys and values). This PR updates the test data to reflect that and the parameter deserializer to handle it.