### PR TITLE
Handle bandit parameter coefficients provided as maps (Objects)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cloud.eppo</groupId>
     <artifactId>eppo-server-sdk</artifactId>
-    <version>2.4.5</version>
+    <version>2.4.6</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Eppo Server-Side SDK for Java</description>

--- a/src/main/java/com/eppo/sdk/deserializer/BanditsDeserializer.java
+++ b/src/main/java/com/eppo/sdk/deserializer/BanditsDeserializer.java
@@ -53,9 +53,10 @@ public class BanditsDeserializer extends StdDeserializer<Map<String, BanditParam
             JsonNode coefficientsNode = modelDataNode.get("coefficients");
 
             Map<String, BanditCoefficients> coefficients = new HashMap<>();
-            coefficientsNode.iterator().forEachRemaining(actionCoefficientsNode -> {
-                BanditCoefficients actionCoefficients = this.parseActionCoefficientsNode(actionCoefficientsNode);
-                coefficients.put(actionCoefficients.getActionKey(), actionCoefficients);
+            Iterator<Map.Entry<String, JsonNode>> coefficientIterator = coefficientsNode.fields();
+            coefficientIterator.forEachRemaining(field -> {
+                BanditCoefficients actionCoefficients = this.parseActionCoefficientsNode(field.getValue());
+                coefficients.put(field.getKey(), actionCoefficients);
             });
 
             modelData.setCoefficients(coefficients);

--- a/src/test/resources/bandits/bandits-parameters-1.json
+++ b/src/test/resources/bandits/bandits-parameters-1.json
@@ -10,8 +10,8 @@
         "gamma": 1.0,
         "defaultActionScore": 0.0,
         "actionProbabilityFloor": 0.0,
-        "coefficients": [
-          {
+        "coefficients": {
+          "nike": {
             "actionKey": "nike",
             "intercept": 1.0,
             "actionNumericCoefficients": [
@@ -50,7 +50,7 @@
               }
             ]
           },
-          {
+          "adidas": {
             "actionKey": "adidas",
             "intercept": 1.1,
             "actionNumericCoefficients": [
@@ -82,7 +82,7 @@
               }
             ]
           }
-        ]
+        }
       }
     },
     {
@@ -94,7 +94,7 @@
         "gamma": 1.0,
         "defaultActionScore": 0.0,
         "actionProbabilityFloor": 0.0,
-        "coefficients": []
+        "coefficients": {}
       }
     }
   ]


### PR DESCRIPTION
_Eppo Internal:_ 🎟️ **Ticket:** [FF-2269](https://linear.app/eppo/issue/FF-2269/adjust-java-sdk-and-upgrade-dogfood-bandit-to-handle-coefficients-as)

This change has the SDK ingest bandit parameter coefficients as a map of actions to that action's coefficients rather than as a list of an action key and associated coefficients.