### PR TITLE
quality: Parameterize branch names for test workflow

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -5,10 +5,25 @@ on:
     paths:
       - '**/*'
 
+  workflow_dispatch:
+
+  workflow_call:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
 env:
   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
   ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
   CI: true
+  SDK_BRANCH_NAME: ${{ inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
+  TEST_DATA_BRANCH_NAME: ${{ inputs.test_data_branch || 'main' }}
 
 jobs:
   lint-test-sdk:
@@ -19,6 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: Eppo-exp/java-server-sdk
+          ref: ${{ env.SDK_BRANCH_NAME }}
           fetch-depth: 0
 
       - name: Set up JDK ${{ matrix.java-version }}
@@ -28,4 +45,4 @@ jobs:
           distribution: 'adopt'
 
       - name: Run tests
-        run: make test-data && ./gradlew check --no-daemon --stacktrace
+        run: make test-data branchName=${{ env.TEST_DATA_BRANCH_NAME }} && ./gradlew check --no-daemon --stacktrace

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -32,6 +32,11 @@ jobs:
       matrix:
         java-version: ['8', '11', '17'] # Define the Java versions to test against
     steps:
+      - name: Display Testing Details
+        run: |
+          echo "Running SDK Test using"
+          echo "Test Data: sdk-test-data@${TEST_DATA_BRANCH_NAME}"
+          echo "SDK Branch: php-sdk@${SDK_BRANCH_NAME}"
       - uses: actions/checkout@v4
         with:
           repository: Eppo-exp/java-server-sdk


### PR DESCRIPTION
🎟️ Fixes FF-3090 towards FF-3085

👯‍♂️ **Related PRs**
- [sdk-test-data#58](https://github.com/Eppo-exp/sdk-test-data/pull/58)
- [js-client-sdk#96](https://github.com/Eppo-exp/js-client-sdk/pull/96)
- [python-sdk#65](https://github.com/Eppo-exp/python-sdk/pull/65)

### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
_This change_
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.
- The test workflow runs using the main branch of sdk-test-data on all main pushes and Pull Requests using the PR's branch

_External to this Change_
[sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows) get two testing workflows.
1. ♻️  "Local Testing"- For all pull request changes, the "Local Testing" workflow calls the reusable SDK workflows, test results are recorded only in the sdk-test-data action. This is run using the main SDK branch and the "current" branch of workflow, i.e. the pull request branch. (SDK repo does not see/is not notified of test failures during PR lifecycle, only on push to main)
2. ♻️ 🧑‍💻 "Remote Testing" - On all pushes to the main branch of sdk-test-data, the SDK testing workflows are triggered to run within their respective repositories, alerting all subscribers of failed runs (repo is red/green).