### PR TITLE
Include Java version 21 in tests

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['8', '11', '17'] # Define the Java versions to test against
+        java-version: ['8', '11', '17', '21'] # Define the Java versions to test against
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Adding Java version 21 to the testing matrix to ensure the SDK operates as expected in a newer version of Java