### PR TITLE
chore: latest common package and move `/api` to baseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:eppo-server-sdk:3.1.0'
+  implementation 'cloud.eppo:eppo-server-sdk:4.0.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:eppo-server-sdk:3.1.0'
+  implementation 'cloud.eppo:eppo-server-sdk:4.0.0'
 }
 ```
 
@@ -58,6 +58,6 @@ repositories {
 }
 
 dependencies {
-  implementation 'cloud.eppo:eppo-server-sdk:3.2.0-SNAPSHOT'
+  implementation 'cloud.eppo:eppo-server-sdk:4.0.1-SNAPSHOT'
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-  api 'cloud.eppo:sdk-common-jvm:3.6.1-SNAPSHOT'
+  api 'cloud.eppo:sdk-common-jvm:3.6.0'
 
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '4.0.1'
+version = '4.1.1'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-  api 'cloud.eppo:sdk-common-jvm:3.5.0'
+  api 'cloud.eppo:sdk-common-jvm:3.5.2'
 
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '4.0.0-SNAPSHOT'
+version = '4.0.1'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   api 'cloud.eppo:sdk-common-jvm:3.5.0'
 
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
   implementation 'org.ehcache:ehcache:3.10.8'
   implementation 'org.slf4j:slf4j-api:2.0.13'
   // Logback classic 1.3.x is compatible with java 8

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 public class EppoClient extends BaseEppoClient {
   private static final Logger log = LoggerFactory.getLogger(EppoClient.class);
 
-  private static final String DEFAULT_HOST = "https://fscdn.eppo.cloud";
   private static final boolean DEFAULT_IS_GRACEFUL_MODE = true;
   private static final boolean DEFAULT_FORCE_REINITIALIZE = false;
   private static final long DEFAULT_POLLING_INTERVAL_MS = 30 * 1000;
@@ -77,7 +76,7 @@ public class EppoClient extends BaseEppoClient {
     private boolean isGracefulMode = DEFAULT_IS_GRACEFUL_MODE;
     private boolean forceReinitialize = DEFAULT_FORCE_REINITIALIZE;
     private long pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
-    private String host = DEFAULT_HOST;
+    private String host = Constants.DEFAULT_BASE_URL;
 
     // Assignment and bandit caching on by default. To disable, call
     // `builder.assignmentCache(null).banditAssignmentCache(null);`

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -37,7 +37,7 @@ public class EppoClient extends BaseEppoClient {
 
   private EppoClient(
       String apiKey,
-      String host,
+      String baseUrl,
       String sdkName,
       String sdkVersion,
       @Nullable AssignmentLogger assignmentLogger,
@@ -47,7 +47,7 @@ public class EppoClient extends BaseEppoClient {
       @Nullable IAssignmentCache banditAssignmentCache) {
     super(
         apiKey,
-        host,
+        baseUrl,
         sdkName,
         sdkVersion,
         assignmentLogger,

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -39,7 +39,6 @@ public class EppoClient extends BaseEppoClient {
       String apiKey,
       String sdkName,
       String sdkVersion,
-      @Nullable @Deprecated String host,
       @Nullable String baseUrl,
       @Nullable AssignmentLogger assignmentLogger,
       @Nullable BanditLogger banditLogger,
@@ -50,7 +49,7 @@ public class EppoClient extends BaseEppoClient {
         apiKey,
         sdkName,
         sdkVersion,
-        host,
+        null,
         baseUrl,
         assignmentLogger,
         banditLogger,
@@ -78,7 +77,6 @@ public class EppoClient extends BaseEppoClient {
     private boolean isGracefulMode = DEFAULT_IS_GRACEFUL_MODE;
     private boolean forceReinitialize = DEFAULT_FORCE_REINITIALIZE;
     private long pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
-    private String host = null; // TODO remove with next major version bump.
     private String apiBaseUrl = null;
 
     // Assignment and bandit caching on by default. To disable, call
@@ -141,16 +139,6 @@ public class EppoClient extends BaseEppoClient {
     }
 
     /**
-     * Overrides the host from where it fetches configurations. This typically should not be
-     * explicitly set so that the default of the Fastly CDN is used. @Deprecated - use `apiBaseUrl`
-     * instead
-     */
-    public Builder host(String host) {
-      this.host = host;
-      return this;
-    }
-
-    /**
      * Overrides the base URL from where the SDK fetches configurations. This typically should not
      * be explicitly set so that the default API URL is used.
      */
@@ -190,7 +178,6 @@ public class EppoClient extends BaseEppoClient {
               apiKey,
               sdkName,
               sdkVersion,
-              host, // TODO remove with next major version bump.
               apiBaseUrl,
               assignmentLogger,
               banditLogger,

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -37,9 +37,10 @@ public class EppoClient extends BaseEppoClient {
 
   private EppoClient(
       String apiKey,
-      String baseUrl,
       String sdkName,
       String sdkVersion,
+      @Nullable @Deprecated String host,
+      @Nullable String baseUrl,
       @Nullable AssignmentLogger assignmentLogger,
       @Nullable BanditLogger banditLogger,
       boolean isGracefulMode,
@@ -47,9 +48,10 @@ public class EppoClient extends BaseEppoClient {
       @Nullable IAssignmentCache banditAssignmentCache) {
     super(
         apiKey,
-        baseUrl,
         sdkName,
         sdkVersion,
+        host,
+        baseUrl,
         assignmentLogger,
         banditLogger,
         null,
@@ -76,7 +78,8 @@ public class EppoClient extends BaseEppoClient {
     private boolean isGracefulMode = DEFAULT_IS_GRACEFUL_MODE;
     private boolean forceReinitialize = DEFAULT_FORCE_REINITIALIZE;
     private long pollingIntervalMs = DEFAULT_POLLING_INTERVAL_MS;
-    private String host = Constants.DEFAULT_BASE_URL;
+    private String host = null; // TODO remove with next major version bump.
+    private String apiBaseUrl = null;
 
     // Assignment and bandit caching on by default. To disable, call
     // `builder.assignmentCache(null).banditAssignmentCache(null);`
@@ -139,10 +142,20 @@ public class EppoClient extends BaseEppoClient {
 
     /**
      * Overrides the host from where it fetches configurations. This typically should not be
-     * explicitly set so that the default of the Fastly CDN is used.
+     * explicitly set so that the default of the Fastly CDN is used. @Deprecated - use `apiBaseUrl`
+     * instead
      */
     public Builder host(String host) {
       this.host = host;
+      return this;
+    }
+
+    /**
+     * Overrides the base URL from where the SDK fetches configurations. This typically should not
+     * be explicitly set so that the default API URL is used.
+     */
+    public Builder apiBaseUrl(String apiBaseUrl) {
+      this.apiBaseUrl = apiBaseUrl;
       return this;
     }
 
@@ -177,7 +190,8 @@ public class EppoClient extends BaseEppoClient {
               apiKey,
               sdkName,
               sdkVersion,
-              host,
+              host, // TODO remove with next major version bump.
+              apiBaseUrl,
               assignmentLogger,
               banditLogger,
               isGracefulMode,

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -287,7 +287,7 @@ public class EppoClientTest {
 
     return new EppoClient.Builder()
         .apiKey(apiKey)
-        .host(TEST_HOST)
+        .apiBaseUrl(Constants.appendApiPathToHost(TEST_HOST))
         .assignmentLogger(mockAssignmentLogger)
         .banditLogger(mockBanditLogger)
         .isGracefulMode(false)
@@ -301,7 +301,7 @@ public class EppoClientTest {
 
     return new EppoClient.Builder()
         .apiKey(DUMMY_FLAG_API_KEY)
-        .host("blag")
+        .apiBaseUrl("blag")
         .assignmentLogger(mockAssignmentLogger)
         .banditLogger(mockBanditLogger)
         .isGracefulMode(isGracefulMode)


### PR DESCRIPTION
towards FF-3558
🎟️ [FF-3558](https://linear.app/eppo/issue/FF-3558/unify-sdk-request-baseurl)

## Motivation and Context
Most, nearly all in fact, of the SDKs use a baseUrl of https://fscdn.eppo.cloud/api and endpoint constants of `/flag-config/v1/config` and `/flag-config/v1/bandits` for flag and bandit requests.
iOS and, at some point, the Java SDK [stopped following](https://github.com/Eppo-exp/sdk-common-jdk/blob/main/src/main/java/cloud/eppo/ConfigurationRequestor.java#L12) this [convention](https://github.com/Eppo-exp/sdk-common-jdk/blob/main/src/main/java/cloud/eppo/Constants.java) instead putting the /apiportion in the endpoint string.

All of the SDKs need to follow the common convention in order for our cross-SDK testing tools (scenario testing, benchmarking) to work seamlessly.

## Changes
- major version bump (required for API and namespace changes)
- use `apiBaseUrl` param instead of host
