### PR TITLE
fix: Respect graceful mode on init (from sdk-common-jvm)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-data:
 	mkdir -p ${tempDir}
 	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
 	cp -r ${gitDataDir}/ufc ${testDataDir}
-	rm ${testDataDir}/ufc/bandit-tests/*.dynamic-typing.json
+	rm -f ${testDataDir}/ufc/bandit-tests/*.dynamic-typing.json
 	rm -rf ${tempDir}
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:eppo-server-sdk:3.1.0'
+  implementation 'cloud.eppo:eppo-server-sdk:4.0.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '4.0.0-SNAPSHOT'
+version = '4.0.1'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-  api 'cloud.eppo:sdk-common-jvm:3.5.0'
+  api 'cloud.eppo:sdk-common-jvm:3.5.4'
 
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -197,17 +197,10 @@ public class EppoClient extends BaseEppoClient {
               pollingIntervalMs,
               pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
 
-      fetchConfigurationsTask.scheduleNext();
-
-      // Kick off the first fetch, respecting graceful mode.
-      try {
-        instance.loadConfiguration();
-      } catch (RuntimeException e) {
-        log.error("Encountered Exception while loading configuration", e);
-        if (!isGracefulMode) {
-          throw e;
-        }
-      }
+      // Kick off the first fetch
+      // Graceful mode is implicit here because `FetchConfigurationsTask` catches and logs errors
+      // without rethrowing.
+      fetchConfigurationsTask.run();
 
       return instance;
     }

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -197,9 +197,11 @@ public class EppoClient extends BaseEppoClient {
               pollingIntervalMs,
               pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
 
+      fetchConfigurationsTask.scheduleNext();
+
       // Kick off the first fetch, respecting graceful mode.
       try {
-        fetchConfigurationsTask.run();
+        instance.loadConfiguration();
       } catch (RuntimeException e) {
         log.error("Encountered Exception while loading configuration", e);
         if (!isGracefulMode) {

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -197,8 +197,15 @@ public class EppoClient extends BaseEppoClient {
               pollingIntervalMs,
               pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
 
-      // Kick off the first fetch
-      fetchConfigurationsTask.run();
+      // Kick off the first fetch, respecting graceful mode.
+      try {
+        fetchConfigurationsTask.run();
+      } catch (RuntimeException e) {
+        log.error("Encountered Exception while loading configuration", e);
+        if (!isGracefulMode) {
+          throw e;
+        }
+      }
 
       return instance;
     }

--- a/src/main/java/cloud/eppo/FetchConfigurationsTask.java
+++ b/src/main/java/cloud/eppo/FetchConfigurationsTask.java
@@ -28,10 +28,6 @@ class FetchConfigurationsTask extends TimerTask {
     } catch (Exception e) {
       log.error("[Eppo SDK] Error fetching experiment configuration", e);
     }
-    scheduleNext();
-  }
-
-  public void scheduleNext() {
 
     long delay = this.intervalInMillis - (long) (Math.random() * this.jitterInMillis);
     FetchConfigurationsTask nextTask =

--- a/src/main/java/cloud/eppo/FetchConfigurationsTask.java
+++ b/src/main/java/cloud/eppo/FetchConfigurationsTask.java
@@ -28,6 +28,10 @@ class FetchConfigurationsTask extends TimerTask {
     } catch (Exception e) {
       log.error("[Eppo SDK] Error fetching experiment configuration", e);
     }
+    scheduleNext();
+  }
+
+  public void scheduleNext() {
 
     long delay = this.intervalInMillis - (long) (Math.random() * this.jitterInMillis);
     FetchConfigurationsTask nextTask =

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -270,6 +270,7 @@ public class EppoClientTest {
     // Initialize and the exception should be thrown.
     try {
       initFailingGracefulClient(false);
+      fail("Exception should have been thrown");
     } catch (RuntimeException e) {
       // Expected
       assertEquals("Intentional Error", e.getMessage());

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -4,7 +4,6 @@ import static cloud.eppo.helpers.AssignmentTestCase.parseTestCaseFile;
 import static cloud.eppo.helpers.AssignmentTestCase.runTestCase;
 import static cloud.eppo.helpers.BanditTestCase.parseBanditTestCaseFile;
 import static cloud.eppo.helpers.BanditTestCase.runBanditTestCase;
-import static cloud.eppo.helpers.TestUtils.mockHttpError;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
## Changes
- Update to latest `sdk-common-jvm`
- Tests for ensuring EppoClient still gives assignment if it fails init.