### PR TITLE
feat: update to latest common for new methods, major bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '4.0.1-SNAPSHOT'
+version = '4.1.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-  api 'cloud.eppo:sdk-common-jvm:3.6.0'
+  api 'cloud.eppo:sdk-common-jvm:3.8.0'
 
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '5.0.0'
+version = '5.0.0-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '4.1.0'
+version = '5.0.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -63,10 +63,11 @@ public class EppoClient extends BaseEppoClient {
   }
 
   /** Stops the client from polling Eppo for updated flag and bandit configurations */
-  public static void stopPolling() {
+  public static void stopPollingSafe() {
     if (pollTimer != null) {
       pollTimer.cancel();
     }
+
   }
 
   /** Builder pattern to initialize the EppoClient singleton */
@@ -186,7 +187,7 @@ public class EppoClient extends BaseEppoClient {
               banditAssignmentCache);
 
       // Stop any active polling
-      stopPolling();
+      stopPollingSafe();
 
       // Set up polling for experiment configurations
       pollTimer = new Timer(true);

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -60,13 +60,6 @@ public class EppoClient extends BaseEppoClient {
         banditAssignmentCache);
   }
 
-  /** Stops the client from polling Eppo for updated flag and bandit configurations */
-  public static void stopPollingSafe() {
-    if (instance != null) {
-      instance.stopPolling();
-    }
-  }
-
   /** Builder pattern to initialize the EppoClient singleton */
   public static class Builder {
     private String apiKey;
@@ -161,6 +154,7 @@ public class EppoClient extends BaseEppoClient {
       String sdkVersion = appDetails.getVersion();
 
       if (instance != null) {
+        // Stop any active polling.
         instance.stopPolling();
         if (forceReinitialize) {
           log.warn(
@@ -184,16 +178,13 @@ public class EppoClient extends BaseEppoClient {
               assignmentCache,
               banditAssignmentCache);
 
-      // Stop any active polling
-      stopPollingSafe();
+      // Fetch first configuration
+      instance.loadConfiguration();
 
       // start polling, if enabled.
       if (pollingIntervalMs > 0) {
         instance.startPolling(pollingIntervalMs, pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
       }
-
-      // Fetch configuration
-      instance.loadConfiguration();
 
       return instance;
     }

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -5,7 +5,6 @@ import cloud.eppo.cache.ExpiringInMemoryAssignmentCache;
 import cloud.eppo.cache.LRUInMemoryAssignmentCache;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.logging.BanditLogger;
-import java.util.Timer;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -26,7 +25,6 @@ public class EppoClient extends BaseEppoClient {
   private static final long DEFAULT_JITTER_INTERVAL_RATIO = 10;
 
   private static EppoClient instance;
-  private static Timer pollTimer;
 
   public static EppoClient getInstance() {
     if (instance == null) {
@@ -64,10 +62,9 @@ public class EppoClient extends BaseEppoClient {
 
   /** Stops the client from polling Eppo for updated flag and bandit configurations */
   public static void stopPollingSafe() {
-    if (pollTimer != null) {
-      pollTimer.cancel();
+    if (instance != null) {
+      instance.stopPolling();
     }
-
   }
 
   /** Builder pattern to initialize the EppoClient singleton */
@@ -164,6 +161,7 @@ public class EppoClient extends BaseEppoClient {
       String sdkVersion = appDetails.getVersion();
 
       if (instance != null) {
+        instance.stopPolling();
         if (forceReinitialize) {
           log.warn(
               "Eppo SDK is already initialized, reinitializing since forceReinitialize is true");
@@ -189,19 +187,13 @@ public class EppoClient extends BaseEppoClient {
       // Stop any active polling
       stopPollingSafe();
 
-      // Set up polling for experiment configurations
-      pollTimer = new Timer(true);
-      FetchConfigurationsTask fetchConfigurationsTask =
-          new FetchConfigurationsTask(
-              () -> instance.loadConfiguration(),
-              pollTimer,
-              pollingIntervalMs,
-              pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
+      // start polling, if enabled.
+      if (pollingIntervalMs > 0) {
+        instance.startPolling(pollingIntervalMs, pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
+      }
 
-      // Kick off the first fetch
-      // Graceful mode is implicit here because `FetchConfigurationsTask` catches and logs errors
-      // without rethrowing.
-      fetchConfigurationsTask.run();
+      // Fetch configuration
+      instance.loadConfiguration();
 
       return instance;
     }

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -91,7 +91,11 @@ public class EppoClientTest {
   @AfterEach
   public void cleanUp() {
     TestUtils.setBaseClientHttpClientOverrideField(null);
-    EppoClient.stopPollingSafe();
+    try {
+      EppoClient.getInstance().stopPolling();
+    } catch (IllegalStateException ex) {
+      // pass: Indicates that the singleton Eppo Client has not yet been initialized.
+    }
   }
 
   @AfterAll
@@ -232,7 +236,7 @@ public class EppoClientTest {
     // Now, the method should have been called twice
     verify(httpClientSpy, times(2)).get(anyString());
 
-    EppoClient.stopPollingSafe();
+    EppoClient.getInstance().stopPolling();
     sleepUninterruptedly(25);
 
     // No more calls since stopped

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -91,7 +91,7 @@ public class EppoClientTest {
   @AfterEach
   public void cleanUp() {
     TestUtils.setBaseClientHttpClientOverrideField(null);
-    EppoClient.stopPolling();
+    EppoClient.stopPollingSafe();
   }
 
   @AfterAll
@@ -232,7 +232,7 @@ public class EppoClientTest {
     // Now, the method should have been called twice
     verify(httpClientSpy, times(2)).get(anyString());
 
-    EppoClient.stopPolling();
+    EppoClient.stopPollingSafe();
     sleepUninterruptedly(25);
 
     // No more calls since stopped

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.*;
 import cloud.eppo.api.Attributes;
 import cloud.eppo.api.BanditActions;
 import cloud.eppo.api.BanditResult;
+import cloud.eppo.api.Configuration;
 import cloud.eppo.helpers.AssignmentTestCase;
 import cloud.eppo.helpers.BanditTestCase;
 import cloud.eppo.helpers.TestUtils;
@@ -18,6 +19,7 @@ import cloud.eppo.logging.Assignment;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.logging.BanditAssignment;
 import cloud.eppo.logging.BanditLogger;
+import cloud.eppo.ufc.dto.VariationType;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -259,6 +261,15 @@ public class EppoClientTest {
     } catch (Exception e) {
       fail("Unexpected exception: " + e);
     }
+  }
+
+  @Test
+  public void testGetConfiguration() {
+    EppoClient eppoClient = initClient(DUMMY_FLAG_API_KEY);
+    Configuration configuration = eppoClient.getConfiguration();
+    assertNotNull(configuration);
+    assertNotNull(configuration.getFlag("numeric_flag"));
+    assertEquals(VariationType.NUMERIC, configuration.getFlagType("numeric_flag"));
   }
 
   public static void mockHttpError() {


### PR DESCRIPTION
_Eppo Internal_
🎟️ Fixes FF-3454
📜 [DD](https://www.notion.so/eppo/New-Java-SDK-methods-getConfiguration-and-getFlagType-19a49cc0114380709ff3e69f020650d8)

- updates to sdk-common-jdk:3.8.0
- `getConfiguration`
- `startPolling` and `stopPolling` as instance methods on `EppoClient`
- bump to v5.0.0

**Breaking Change** 
The static method `EppoClient.stopPolling()` has been removed in favour of using the instance method `stopPolling()`.

```java
// This method has been removed
EppoClient.stopPolling();

// use this instead
getInstance().stopPolling();

// If you are unsure whether the EppoClient has been initialized when you wish to call stopPolling, try-catch:
try {
  EppoClient.getInstance().stopPolling();
} catch (IllegalStateException ex) {
  // pass: Indicates that the singleton Eppo Client has not yet been initialized.
}
```