### PR TITLE
chore: rename apiKey to sdkKey for consistency

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+---
+labels: mergeable
+---
+_Eppo Internal_
+[//]: #  (Link to the issue or doc corresponding to this chunk of work)
+🎟️ Fixes: #__issue__
+📜 Design Doc (if applicable)
+
+## Motivation and Context
+[//]: #  (Why is this change required? What problem does it solve?)
+
+## Description
+[//]: # (Describe your changes in detail)
+
+## How has this been documented?
+[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues)
+
+## How has this been tested?
+[//]: # (Please describe in detail how you tested your changes)
+
+
+[//]: # (OPTIONAL)
+[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '4.0.1-SNAPSHOT'
+version = '4.1.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-  api 'cloud.eppo:sdk-common-jvm:3.6.0'
+  api 'cloud.eppo:sdk-common-jvm:3.8.0'
 
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '5.0.0'
+version = '5.0.0-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 group = 'cloud.eppo'
-version = '4.1.0'
+version = '5.0.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 import org.apache.tools.ant.filters.ReplaceTokens

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -63,10 +63,11 @@ public class EppoClient extends BaseEppoClient {
   }
 
   /** Stops the client from polling Eppo for updated flag and bandit configurations */
-  public static void stopPolling() {
+  public static void stopPollingSafe() {
     if (pollTimer != null) {
       pollTimer.cancel();
     }
+
   }
 
   /** Builder pattern to initialize the EppoClient singleton */
@@ -186,7 +187,7 @@ public class EppoClient extends BaseEppoClient {
               banditAssignmentCache);
 
       // Stop any active polling
-      stopPolling();
+      stopPollingSafe();
 
       // Set up polling for experiment configurations
       pollTimer = new Timer(true);

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -6,6 +6,7 @@ import cloud.eppo.cache.LRUInMemoryAssignmentCache;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.logging.BanditLogger;
 import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,7 @@ public class EppoClient extends BaseEppoClient {
   }
 
   private EppoClient(
-      String apiKey,
+      String sdkKey,
       String sdkName,
       String sdkVersion,
       @Nullable String baseUrl,
@@ -44,7 +45,7 @@ public class EppoClient extends BaseEppoClient {
       @Nullable IAssignmentCache assignmentCache,
       @Nullable IAssignmentCache banditAssignmentCache) {
     super(
-        apiKey,
+        sdkKey,
         sdkName,
         sdkVersion,
         null,
@@ -60,9 +61,18 @@ public class EppoClient extends BaseEppoClient {
         banditAssignmentCache);
   }
 
+  /**
+   * Creates a new EppoClient Builder object with the specified SDK Key.
+   *
+   * @param sdkKey (see <a href="https://docs.geteppo.com/sdks/sdk-keys/">SDK Keys</a>)
+   */
+  public static Builder builder(@NotNull String sdkKey) {
+    return new Builder(sdkKey);
+  }
+
   /** Builder pattern to initialize the EppoClient singleton */
   public static class Builder {
-    private String apiKey;
+    private final String sdkKey;
     private AssignmentLogger assignmentLogger;
     private BanditLogger banditLogger;
     private boolean isGracefulMode = DEFAULT_IS_GRACEFUL_MODE;
@@ -76,10 +86,8 @@ public class EppoClient extends BaseEppoClient {
     private IAssignmentCache banditAssignmentCache =
         new ExpiringInMemoryAssignmentCache(10, TimeUnit.MINUTES);
 
-    /** Sets the API Key--created within the eppo application--to use. This is required. */
-    public Builder apiKey(String apiKey) {
-      this.apiKey = apiKey;
-      return this;
+    private Builder(@NotNull String sdkKey) {
+      this.sdkKey = sdkKey;
     }
 
     /**
@@ -168,7 +176,7 @@ public class EppoClient extends BaseEppoClient {
 
       instance =
           new EppoClient(
-              apiKey,
+              sdkKey,
               sdkName,
               sdkVersion,
               apiBaseUrl,

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -60,13 +60,6 @@ public class EppoClient extends BaseEppoClient {
         banditAssignmentCache);
   }
 
-  /** Stops the client from polling Eppo for updated flag and bandit configurations */
-  public static void stopPollingSafe() {
-    if (instance != null) {
-      instance.stopPolling();
-    }
-  }
-
   /** Builder pattern to initialize the EppoClient singleton */
   public static class Builder {
     private String apiKey;
@@ -161,6 +154,7 @@ public class EppoClient extends BaseEppoClient {
       String sdkVersion = appDetails.getVersion();
 
       if (instance != null) {
+        // Stop any active polling.
         instance.stopPolling();
         if (forceReinitialize) {
           log.warn(
@@ -184,16 +178,13 @@ public class EppoClient extends BaseEppoClient {
               assignmentCache,
               banditAssignmentCache);
 
-      // Stop any active polling
-      stopPollingSafe();
+      // Fetch first configuration
+      instance.loadConfiguration();
 
       // start polling, if enabled.
       if (pollingIntervalMs > 0) {
         instance.startPolling(pollingIntervalMs, pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
       }
-
-      // Fetch configuration
-      instance.loadConfiguration();
 
       return instance;
     }

--- a/src/main/java/cloud/eppo/EppoClient.java
+++ b/src/main/java/cloud/eppo/EppoClient.java
@@ -5,7 +5,6 @@ import cloud.eppo.cache.ExpiringInMemoryAssignmentCache;
 import cloud.eppo.cache.LRUInMemoryAssignmentCache;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.logging.BanditLogger;
-import java.util.Timer;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -26,7 +25,6 @@ public class EppoClient extends BaseEppoClient {
   private static final long DEFAULT_JITTER_INTERVAL_RATIO = 10;
 
   private static EppoClient instance;
-  private static Timer pollTimer;
 
   public static EppoClient getInstance() {
     if (instance == null) {
@@ -64,10 +62,9 @@ public class EppoClient extends BaseEppoClient {
 
   /** Stops the client from polling Eppo for updated flag and bandit configurations */
   public static void stopPollingSafe() {
-    if (pollTimer != null) {
-      pollTimer.cancel();
+    if (instance != null) {
+      instance.stopPolling();
     }
-
   }
 
   /** Builder pattern to initialize the EppoClient singleton */
@@ -164,6 +161,7 @@ public class EppoClient extends BaseEppoClient {
       String sdkVersion = appDetails.getVersion();
 
       if (instance != null) {
+        instance.stopPolling();
         if (forceReinitialize) {
           log.warn(
               "Eppo SDK is already initialized, reinitializing since forceReinitialize is true");
@@ -189,19 +187,13 @@ public class EppoClient extends BaseEppoClient {
       // Stop any active polling
       stopPollingSafe();
 
-      // Set up polling for experiment configurations
-      pollTimer = new Timer(true);
-      FetchConfigurationsTask fetchConfigurationsTask =
-          new FetchConfigurationsTask(
-              () -> instance.loadConfiguration(),
-              pollTimer,
-              pollingIntervalMs,
-              pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
+      // start polling, if enabled.
+      if (pollingIntervalMs > 0) {
+        instance.startPolling(pollingIntervalMs, pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
+      }
 
-      // Kick off the first fetch
-      // Graceful mode is implicit here because `FetchConfigurationsTask` catches and logs errors
-      // without rethrowing.
-      fetchConfigurationsTask.run();
+      // Fetch configuration
+      instance.loadConfiguration();
 
       return instance;
     }

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -91,7 +91,11 @@ public class EppoClientTest {
   @AfterEach
   public void cleanUp() {
     TestUtils.setBaseClientHttpClientOverrideField(null);
-    EppoClient.stopPollingSafe();
+    try {
+      EppoClient.getInstance().stopPolling();
+    } catch (IllegalStateException ex) {
+      // pass: Indicates that the singleton Eppo Client has not yet been initialized.
+    }
   }
 
   @AfterAll
@@ -232,7 +236,7 @@ public class EppoClientTest {
     // Now, the method should have been called twice
     verify(httpClientSpy, times(2)).get(anyString());
 
-    EppoClient.stopPollingSafe();
+    EppoClient.getInstance().stopPolling();
     sleepUninterruptedly(25);
 
     // No more calls since stopped

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -91,7 +91,7 @@ public class EppoClientTest {
   @AfterEach
   public void cleanUp() {
     TestUtils.setBaseClientHttpClientOverrideField(null);
-    EppoClient.stopPolling();
+    EppoClient.stopPollingSafe();
   }
 
   @AfterAll
@@ -232,7 +232,7 @@ public class EppoClientTest {
     // Now, the method should have been called twice
     verify(httpClientSpy, times(2)).get(anyString());
 
-    EppoClient.stopPolling();
+    EppoClient.stopPollingSafe();
     sleepUninterruptedly(25);
 
     // No more calls since stopped

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.*;
 import cloud.eppo.api.Attributes;
 import cloud.eppo.api.BanditActions;
 import cloud.eppo.api.BanditResult;
+import cloud.eppo.api.Configuration;
 import cloud.eppo.helpers.AssignmentTestCase;
 import cloud.eppo.helpers.BanditTestCase;
 import cloud.eppo.helpers.TestUtils;
@@ -18,6 +19,7 @@ import cloud.eppo.logging.Assignment;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.logging.BanditAssignment;
 import cloud.eppo.logging.BanditLogger;
+import cloud.eppo.ufc.dto.VariationType;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -259,6 +261,15 @@ public class EppoClientTest {
     } catch (Exception e) {
       fail("Unexpected exception: " + e);
     }
+  }
+
+  @Test
+  public void testGetConfiguration() {
+    EppoClient eppoClient = initClient(DUMMY_FLAG_API_KEY);
+    Configuration configuration = eppoClient.getConfiguration();
+    assertNotNull(configuration);
+    assertNotNull(configuration.getFlag("numeric_flag"));
+    assertEquals(VariationType.NUMERIC, configuration.getFlagType("numeric_flag"));
   }
 
   public static void mockHttpError() {

--- a/src/test/java/cloud/eppo/EppoClientTest.java
+++ b/src/test/java/cloud/eppo/EppoClientTest.java
@@ -203,7 +203,7 @@ public class EppoClientTest {
   @Test
   public void testReinitializeWithoutForcing() {
     EppoClient firstInstance = initClient(DUMMY_FLAG_API_KEY);
-    EppoClient secondInstance = new EppoClient.Builder().apiKey(DUMMY_FLAG_API_KEY).buildAndInit();
+    EppoClient secondInstance = EppoClient.builder(DUMMY_FLAG_API_KEY).buildAndInit();
 
     assertSame(firstInstance, secondInstance);
   }
@@ -212,7 +212,7 @@ public class EppoClientTest {
   public void testReinitializeWitForcing() {
     EppoClient firstInstance = initClient(DUMMY_FLAG_API_KEY);
     EppoClient secondInstance =
-        new EppoClient.Builder().apiKey(DUMMY_FLAG_API_KEY).forceReinitialize(true).buildAndInit();
+        EppoClient.builder(DUMMY_FLAG_API_KEY).forceReinitialize(true).buildAndInit();
 
     assertNotSame(firstInstance, secondInstance);
   }
@@ -223,8 +223,7 @@ public class EppoClientTest {
     EppoHttpClient httpClientSpy = spy(httpClient);
     TestUtils.setBaseClientHttpClientOverrideField(httpClientSpy);
 
-    new EppoClient.Builder()
-        .apiKey(DUMMY_FLAG_API_KEY)
+    EppoClient.builder(DUMMY_FLAG_API_KEY)
         .pollingIntervalMs(20)
         .forceReinitialize(true)
         .buildAndInit();
@@ -300,8 +299,7 @@ public class EppoClientTest {
     mockAssignmentLogger = mock(AssignmentLogger.class);
     mockBanditLogger = mock(BanditLogger.class);
 
-    return new EppoClient.Builder()
-        .apiKey(apiKey)
+    return EppoClient.builder(apiKey)
         .apiBaseUrl(Constants.appendApiPathToHost(TEST_HOST))
         .assignmentLogger(mockAssignmentLogger)
         .banditLogger(mockBanditLogger)
@@ -314,8 +312,7 @@ public class EppoClientTest {
     mockAssignmentLogger = mock(AssignmentLogger.class);
     mockBanditLogger = mock(BanditLogger.class);
 
-    return new EppoClient.Builder()
-        .apiKey(DUMMY_FLAG_API_KEY)
+    return EppoClient.builder(DUMMY_FLAG_API_KEY)
         .apiBaseUrl("blag")
         .assignmentLogger(mockAssignmentLogger)
         .banditLogger(mockBanditLogger)


### PR DESCRIPTION
_Eppo Internal_
[//]: #  (Link to the issue or doc corresponding to this chunk of work)
🎟️ Fixes FF-4060
🧵 slack

## Motivation and Context
We are renaming instances of API Key to SDK Key for
1. consistency and;
2. to differentiate from the API keys used to connect to the Eppo API.

## Description
- Since API Key is required, move it from a builder method to the constructor
- To keep constructors private, the builder is created from a static method on `EppoClient`

## How has this been documented?
[FF-4061](https://linear.app/eppo/issue/FF-4061/[java-docs])

## How has this been tested?
- no functional changes, only facade
